### PR TITLE
TTC-40: Add multiple tee time slots per booking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -690,7 +690,8 @@ When asked to address PR feedback, follow this system:
 
 Before writing custom code to work around a perceived limitation (especially in KMP/Swift interop), verify the assumption first:
 
-1. **Check what already exists** - Before writing a helper/extension, ask: "Does something like this already exist?" Common operations (comparison, formatting, conversion) often have built-in solutions.
+1. **Check what already exists**
+   - For swift/kotlin interop issus: Look at the generated Swift code and headers to see what is available. 
 
 2. **Verify SKIE behavior** - SKIE exposes many Kotlin features to Swift that might not be obvious:
    - `Comparable` types expose `compareTo()` methods in Swift
@@ -700,7 +701,9 @@ Before writing custom code to work around a perceived limitation (especially in 
 
 3. **Test before implementing** - If you think a Kotlin method/property isn't available in Swift, try using it first before writing a workaround. The compilation error (or success) will confirm your assumption.
 
-4. **Question platform-specific code** - If you find yourself writing iOS-only or Android-only code for something that seems like it should be shared, pause and investigate whether a shared solution already exists.
+4. **Ask** - Before writing a helper/extension, ask: "Does something like this already exist?" Common operations (comparison, formatting, conversion) often have built-in solutions.
+
+5. **Question platform-specific code** - If you find yourself writing iOS-only or Android-only code for something that seems like it should be shared, pause and investigate whether a shared solution already exists.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -686,6 +686,22 @@ When asked to address PR feedback, follow this system:
 - Verify platform-specific dependencies in build.gradle.kts
 - Ensure SKIE plugin is applied for iOS interop
 
+## Verifying Assumptions Before Writing Workarounds
+
+Before writing custom code to work around a perceived limitation (especially in KMP/Swift interop), verify the assumption first:
+
+1. **Check what already exists** - Before writing a helper/extension, ask: "Does something like this already exist?" Common operations (comparison, formatting, conversion) often have built-in solutions.
+
+2. **Verify SKIE behavior** - SKIE exposes many Kotlin features to Swift that might not be obvious:
+   - `Comparable` types expose `compareTo()` methods in Swift
+   - Kotlin Flows become Swift AsyncSequences
+   - Sealed classes get proper Swift enum-like handling
+   - Check SKIE documentation (https://skie.touchlab.co) when unsure
+
+3. **Test before implementing** - If you think a Kotlin method/property isn't available in Swift, try using it first before writing a workaround. The compilation error (or success) will confirm your assumption.
+
+4. **Question platform-specific code** - If you find yourself writing iOS-only or Android-only code for something that seems like it should be shared, pause and investigate whether a shared solution already exists.
+
 ---
 
 # Key Architectural Concepts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -589,6 +589,12 @@ When asked to address PR feedback, follow this system:
 - For "Comment" reviews, use judgment about what clearly needs fixing vs. what's discussion
 - **When uncertain, ask for clarification** - collaboration is key and git makes rollback easy
 
+**Discussion Comments:**
+- When a comment is marked "For discussion:", "Let's discuss:", "Question:", or uses similar exploratory language, do NOT immediately implement changes
+- Instead, reply to the PR comment directly (using `gh api` or `gh pr comment`) with analysis and thoughts
+- Wait for the user's response before making any code changes
+- This creates a documented record of architectural decisions in the PR for future reference
+
 **Process for Addressing PR Feedback:**
 1. Fetch PR details: `gh pr view <pr-number>`
 2. Read all "Request Changes" reviews and their comments

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
@@ -1,6 +1,5 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,27 +7,23 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,23 +34,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import net.bradball.teetimecaddie.features.teetimes.TTR
-import kotlin.time.ExperimentalTime
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
+import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
 import net.bradball.teetimecaddie.android.ui.common.TtcDatePicker
-import net.bradball.teetimecaddie.android.ui.common.TtcTimePicker
 import net.bradball.teetimecaddie.android.ui.common.buttons.LoadingButton
 import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.android.ui.common.rememberTtcDatePickerState
-import net.bradball.teetimecaddie.android.ui.common.rememberTtcTimePickerState
 import net.bradball.teetimecaddie.android.ui.common.selectedDate
 import net.bradball.teetimecaddie.core.models.GR
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
+import net.bradball.teetimecaddie.features.teetimes.TTR
 
 @Composable
 fun AddTeeTimeScreen(
@@ -72,6 +65,9 @@ fun AddTeeTimeScreen(
 
     AddTeeTimeContent(
         showLoadingProgress = viewModel.showLoadingProgress,
+        timeSlots = viewModel.timeSlots,
+        onAddTimeSlot = viewModel::addTimeSlot,
+        onUpdatePlayerCount = viewModel::updatePlayerCount,
         onSaveClick = viewModel::saveTeeTime,
         onBackClick = onBack
     )
@@ -81,14 +77,15 @@ fun AddTeeTimeScreen(
 @Composable
 private fun AddTeeTimeContent(
     showLoadingProgress: Boolean,
-    onSaveClick: (String, LocalDate?, LocalTime?, Int) -> Unit,
+    timeSlots: List<TeeTimeSlot>,
+    onAddTimeSlot: (LocalTime) -> Boolean,
+    onUpdatePlayerCount: (LocalTime, Int) -> Unit,
+    onSaveClick: (String, LocalDate?) -> Unit,
     onBackClick: () -> Unit
 ) {
-    var courseName by remember { mutableStateOf("")}
-    var date = rememberTtcDatePickerState()
-    var time = rememberTtcTimePickerState()
-    var players by remember { mutableStateOf(4) }
-
+    var courseName by remember { mutableStateOf("") }
+    val date = rememberTtcDatePickerState()
+    var showTimePickerDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -96,7 +93,7 @@ private fun AddTeeTimeContent(
                 title = { Text(stringResource(TTR.strings.add_tee_time.resourceId)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
-                        Icon(TtcIcons.ARROW_BACK.painter, contentDescription = stringResource(GR.strings.back.resourceId)) 
+                        Icon(TtcIcons.ARROW_BACK.painter, contentDescription = stringResource(GR.strings.back.resourceId))
                     }
                 }
             )
@@ -120,24 +117,15 @@ private fun AddTeeTimeContent(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Date Picker Field
-//            DatePickerField(
-//                selectedDate = selectedDate,
-//                onDateSelected = onDateSelected,
-//                label = "Date (MM/DD/YYYY)"
-//            )
             TtcDatePicker(pickerState = date)
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-            // Time Picker Field
-            TtcTimePicker(pickerState = time)
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            // Number of Players Slider
-            NumberOfPlayersField(
-                numberOfPlayers = players,
-                onNumberChanged = { players = it }
+            // Tee Times Section
+            TeeTimesSection(
+                timeSlots = timeSlots,
+                onAddTimeClick = { showTimePickerDialog = true },
+                onUpdatePlayerCount = onUpdatePlayerCount
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -145,106 +133,137 @@ private fun AddTeeTimeContent(
             // Save Button
             LoadingButton(
                 text = stringResource(TTR.strings.button_create.resourceId),
-                onClick = { onSaveClick(courseName, date.selectedDate, time.selectedTime, players) },
-                enabled = courseName.isNotBlank() && date.selectedDate != null && time != null,
+                onClick = { onSaveClick(courseName, date.selectedDate) },
+                enabled = courseName.isNotBlank() && date.selectedDate != null && timeSlots.isNotEmpty(),
                 modifier = Modifier.fillMaxWidth(),
                 isLoading = showLoadingProgress
             )
         }
     }
+
+    // Time Picker Dialog
+    if (showTimePickerDialog) {
+        AddTimePickerDialog(
+            onDismiss = { showTimePickerDialog = false },
+            onTimeSelected = { time ->
+                onAddTimeSlot(time)
+                showTimePickerDialog = false
+            }
+        )
+    }
 }
 
-
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TimePickerField(
-    selectedTime: LocalTime?,
-    onTimeSelected: (LocalTime) -> Unit,
-    label: String
+private fun TeeTimesSection(
+    timeSlots: List<TeeTimeSlot>,
+    onAddTimeClick: () -> Unit,
+    onUpdatePlayerCount: (LocalTime, Int) -> Unit
 ) {
-    var showDialog by remember { mutableStateOf(false) }
-
-    OutlinedTextField(
-        value = selectedTime?.let { formatTime(it) } ?: "",
-        onValueChange = {},
-        label = { Text(label) },
-        readOnly = true,
-        trailingIcon = {
-            IconButton(onClick = { showDialog = true }) {
-                Icon(TtcIcons.CALENDAR.painter, "Select Time")
-            }
-        },
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { showDialog = true }
-    )
-
-    if (showDialog) {
-        val timePickerState = rememberTimePickerState(
-            initialHour = selectedTime?.hour ?: 9,
-            initialMinute = selectedTime?.minute ?: 0
+    Column {
+        // Section Header
+        Text(
+            text = stringResource(TTR.strings.tee_times_section_header.resourceId),
+            style = MaterialTheme.typography.titleMedium
         )
-        TimePickerDialog(
-            onDismissRequest = { showDialog = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    onTimeSelected(LocalTime(timePickerState.hour, timePickerState.minute))
-                    showDialog = false
-                }) {
-                    Text("OK")
-                }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // List of time slots
+        if (timeSlots.isNotEmpty()) {
+            timeSlots.forEach { slot ->
+                TimeSlotRow(
+                    slot = slot,
+                    onUpdatePlayerCount = { players -> onUpdatePlayerCount(slot.time, players) }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             }
+        }
+
+        // Add Time Button
+        OutlinedButton(
+            onClick = onAddTimeClick,
+            modifier = Modifier.fillMaxWidth()
         ) {
-            TimePicker(state = timePickerState)
+            Icon(
+                TtcIcons.ADD.painter,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Text(stringResource(TTR.strings.add_time_button.resourceId))
         }
     }
 }
 
 @Composable
-private fun NumberOfPlayersField(
-    numberOfPlayers: Int,
-    onNumberChanged: (Int) -> Unit
+private fun TimeSlotRow(
+    slot: TeeTimeSlot,
+    onUpdatePlayerCount: (Int) -> Unit
 ) {
     Column {
+        // Time display
         Text(
-            text = stringResource(TTR.strings.field_Label_Players.resourceId),
-            style = MaterialTheme.typography.bodyMedium
+            text = formatTime(slot.time),
+            style = MaterialTheme.typography.titleMedium
         )
-        Spacer(modifier = Modifier.height(8.dp))
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        // Player count slider
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
+            Text(
+                text = stringResource(TTR.strings.players_label.resourceId),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.width(8.dp))
             Slider(
-                value = numberOfPlayers.toFloat(),
-                onValueChange = { onNumberChanged(it.toInt()) },
+                value = slot.numberOfPlayers.toFloat(),
+                onValueChange = { onUpdatePlayerCount(it.toInt()) },
                 valueRange = 1f..4f,
                 steps = 2,
                 modifier = Modifier.weight(1f)
             )
-            Spacer(modifier = Modifier.width(16.dp))
+            Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = numberOfPlayers.toString(),
-                style = MaterialTheme.typography.headlineSmall
+                text = slot.numberOfPlayers.toString(),
+                style = MaterialTheme.typography.titleMedium
             )
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun TimePickerDialog(
-    onDismissRequest: () -> Unit,
-    confirmButton: @Composable () -> Unit,
-    content: @Composable () -> Unit
+private fun AddTimePickerDialog(
+    onDismiss: () -> Unit,
+    onTimeSelected: (LocalTime) -> Unit
 ) {
+    val timePickerState = rememberTimePickerState(
+        initialHour = 9,
+        initialMinute = 0,
+        is24Hour = false
+    )
+
     AlertDialog(
-        onDismissRequest = onDismissRequest,
-        confirmButton = confirmButton,
-        dismissButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text("Cancel")
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onTimeSelected(LocalTime(timePickerState.hour, timePickerState.minute))
+                }
+            ) {
+                Text(stringResource(GR.strings.ok.resourceId))
             }
         },
-        text = content
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(GR.strings.cancel.resourceId))
+            }
+        },
+        text = {
+            TimeInput(state = timePickerState)
+        }
     )
 }
 
@@ -252,4 +271,34 @@ private fun formatTime(time: LocalTime): String {
     val hour = if (time.hour == 0 || time.hour == 12) 12 else time.hour % 12
     val amPm = if (time.hour < 12) "AM" else "PM"
     return "$hour:${time.minute.toString().padStart(2, '0')} $amPm"
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddTeeTimeContentPreview() {
+    MyApplicationTheme {
+        AddTeeTimeContent(
+            showLoadingProgress = false,
+            timeSlots = emptyList(),
+            onAddTimeSlot = { true },
+            onUpdatePlayerCount = { _, _ -> },
+            onSaveClick = { _, _ -> },
+            onBackClick = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AddTeeTimeContentWithTimesPreview() {
+    MyApplicationTheme {
+        AddTeeTimeContent(
+            showLoadingProgress = false,
+            timeSlots = previewTeeTimeSlotList,
+            onAddTimeSlot = { true },
+            onUpdatePlayerCount = { _, _ -> },
+            onSaveClick = { _, _ -> },
+            onBackClick = { }
+        )
+    }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -21,10 +20,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,10 +37,12 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
 import net.bradball.teetimecaddie.android.ui.common.TtcDatePicker
+import net.bradball.teetimecaddie.android.ui.common.TtcTimePickerDialog
 import net.bradball.teetimecaddie.android.ui.common.buttons.LoadingButton
 import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.android.ui.common.rememberTtcDatePickerState
 import net.bradball.teetimecaddie.android.ui.common.selectedDate
+import net.bradball.teetimecaddie.core.extensions.formattedTime
 import net.bradball.teetimecaddie.core.models.GR
 import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
@@ -143,7 +141,7 @@ private fun AddTeeTimeContent(
 
     // Time Picker Dialog
     if (showTimePickerDialog) {
-        AddTimePickerDialog(
+        TtcTimePickerDialog(
             onDismiss = { showTimePickerDialog = false },
             onTimeSelected = { time ->
                 onAddTimeSlot(time)
@@ -202,7 +200,7 @@ private fun TimeSlotRow(
     Column {
         // Time display
         Text(
-            text = formatTime(slot.time),
+            text = slot.time.formattedTime,
             style = MaterialTheme.typography.titleMedium
         )
 
@@ -231,46 +229,6 @@ private fun TimeSlotRow(
             )
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AddTimePickerDialog(
-    onDismiss: () -> Unit,
-    onTimeSelected: (LocalTime) -> Unit
-) {
-    val timePickerState = rememberTimePickerState(
-        initialHour = 9,
-        initialMinute = 0,
-        is24Hour = false
-    )
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    onTimeSelected(LocalTime(timePickerState.hour, timePickerState.minute))
-                }
-            ) {
-                Text(stringResource(GR.strings.ok.resourceId))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(GR.strings.cancel.resourceId))
-            }
-        },
-        text = {
-            TimeInput(state = timePickerState)
-        }
-    )
-}
-
-private fun formatTime(time: LocalTime): String {
-    val hour = if (time.hour == 0 || time.hour == 12) 12 else time.hour % 12
-    val amPm = if (time.hour < 12) "AM" else "PM"
-    return "$hour:${time.minute.toString().padStart(2, '0')} $amPm"
 }
 
 @Preview(showBackground = true)

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeViewModel.kt
@@ -1,7 +1,7 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime
 
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
@@ -10,9 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
-import net.bradball.teetimecaddie.core.analytics.AnalyticsScreen
-import net.bradball.teetimecaddie.core.analytics.EventManager
-import net.bradball.teetimecaddie.core.analytics.ScreenType
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.features.auth.AuthRepository
 import net.bradball.teetimecaddie.features.teetimes.TeeTimesRepository
 import javax.inject.Inject
@@ -20,8 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class AddTeeTimeViewModel @Inject constructor(
     private val teeTimesRepo: TeeTimesRepository,
-    private val authRepo: AuthRepository,
-    private val eventManager: EventManager
+    private val authRepo: AuthRepository
 ): ViewModel() {
 
     // UI state
@@ -31,8 +28,55 @@ class AddTeeTimeViewModel @Inject constructor(
     var saveSuccess: Boolean by mutableStateOf(false)
         private set
 
-    fun saveTeeTime(courseName: String, date: LocalDate?, time: LocalTime?, players: Int) {
-        if (date == null || time == null) return
+    // List of tee time slots
+    private val _timeSlots = mutableStateListOf<TeeTimeSlot>()
+    val timeSlots: List<TeeTimeSlot> get() = _timeSlots.sortedBy { it.time }
+
+    /**
+     * Adds a new time slot with the default number of players (4).
+     * If the time already exists in the list, it will not be added.
+     *
+     * @param time The time to add.
+     * @return true if the time was added, false if it already existed.
+     */
+    fun addTimeSlot(time: LocalTime): Boolean {
+        if (_timeSlots.any { it.time == time }) {
+            return false
+        }
+        _timeSlots.add(TeeTimeSlot(time = time, numberOfPlayers = 4))
+        return true
+    }
+
+    /**
+     * Updates the number of players for a specific time slot.
+     *
+     * @param time The time of the slot to update.
+     * @param numberOfPlayers The new number of players (1-4).
+     */
+    fun updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        val index = _timeSlots.indexOfFirst { it.time == time }
+        if (index != -1) {
+            _timeSlots[index] = _timeSlots[index].copy(numberOfPlayers = numberOfPlayers.coerceIn(1, 4))
+        }
+    }
+
+    /**
+     * Removes a time slot from the list.
+     *
+     * @param time The time of the slot to remove.
+     */
+    fun removeTimeSlot(time: LocalTime) {
+        _timeSlots.removeAll { it.time == time }
+    }
+
+    /**
+     * Saves the tee time with all added time slots.
+     *
+     * @param courseName The name of the golf course.
+     * @param date The date of the tee time.
+     */
+    fun saveTeeTime(courseName: String, date: LocalDate?) {
+        if (date == null || _timeSlots.isEmpty()) return
         viewModelScope.launch {
             showLoadingProgress = true
             try {
@@ -40,8 +84,7 @@ class AddTeeTimeViewModel @Inject constructor(
                     createdBy = authRepo.currentUser.id,
                     course = courseName,
                     date = date,
-                    time = time,
-                    numberOfPlayers = players
+                    times = _timeSlots.toList()
                 )
                 saveSuccess = true
             } finally {

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
@@ -18,11 +18,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
 import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.core.models.TeeTime
-import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeList
 
@@ -79,7 +77,7 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = formatTimes(teeTime.times),
+                        text = teeTime.formattedTimes,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -105,17 +103,6 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
             }
         }
     }
-}
-
-private fun formatTimes(times: List<TeeTimeSlot>): String {
-    return times.sortedBy { it.time }.joinToString(", ") { formatTime(it.time) }
-}
-
-private fun formatTime(time: LocalTime): String {
-    val hour = if (time.hour == 0) 12 else if (time.hour > 12) time.hour - 12 else time.hour
-    val minute = time.minute.toString().padStart(2, '0')
-    val amPm = if (time.hour < 12) "AM" else "PM"
-    return "$hour:$minute $amPm"
 }
 
 @Preview

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
@@ -18,11 +18,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
 import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.core.models.previewTeeTime
+import net.bradball.teetimecaddie.core.models.previewTeeTimeList
 import net.bradball.teetimecaddie.core.models.shortDate
+import net.bradball.teetimecaddie.core.models.totalPlayers
 
 @Composable
 fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
@@ -65,6 +69,7 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
+                // Display all times in ascending order
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -76,14 +81,14 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = formatTime(teeTime.time),
+                        text = formatTimes(teeTime.times),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
             }
 
-            // Player count (right)
+            // Total player count (right)
             Row(
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -95,7 +100,7 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = teeTime.numberOfPlayers.toString(),
+                    text = teeTime.totalPlayers.toString(),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface
                 )
@@ -104,7 +109,11 @@ fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
     }
 }
 
-private fun formatTime(time: kotlinx.datetime.LocalTime): String {
+private fun formatTimes(times: List<TeeTimeSlot>): String {
+    return times.sortedBy { it.time }.joinToString(", ") { formatTime(it.time) }
+}
+
+private fun formatTime(time: LocalTime): String {
     val hour = if (time.hour == 0) 12 else if (time.hour > 12) time.hour - 12 else time.hour
     val minute = time.minute.toString().padStart(2, '0')
     val amPm = if (time.hour < 12) "AM" else "PM"
@@ -116,5 +125,13 @@ private fun formatTime(time: kotlinx.datetime.LocalTime): String {
 fun TeeTimeCardPreview() {
     MyApplicationTheme {
         TeeTimeCard(previewTeeTime)
+    }
+}
+
+@Preview
+@Composable
+fun TeeTimeCardMultipleTimesPreview() {
+    MyApplicationTheme {
+        TeeTimeCard(previewTeeTimeList[1]) // This one has 2 times
     }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
@@ -25,8 +25,6 @@ import net.bradball.teetimecaddie.core.models.TeeTime
 import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeList
-import net.bradball.teetimecaddie.core.models.shortDate
-import net.bradball.teetimecaddie.core.models.totalPlayers
 
 @Composable
 fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/TtcTimePickerDialog.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/TtcTimePickerDialog.kt
@@ -1,0 +1,56 @@
+package net.bradball.teetimecaddie.android.ui.common
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import kotlinx.datetime.LocalTime
+import net.bradball.teetimecaddie.core.models.GR
+
+/**
+ * A reusable time picker dialog that allows users to select a time.
+ *
+ * @param onDismiss Callback when the user dismisses the dialog.
+ * @param onTimeSelected Callback when the user confirms a time selection.
+ * @param initialHour The initial hour to display (default 9).
+ * @param initialMinute The initial minute to display (default 0).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TtcTimePickerDialog(
+    onDismiss: () -> Unit,
+    onTimeSelected: (LocalTime) -> Unit,
+    initialHour: Int = 9,
+    initialMinute: Int = 0
+) {
+    val timePickerState = rememberTimePickerState(
+        initialHour = initialHour,
+        initialMinute = initialMinute,
+        is24Hour = false
+    )
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onTimeSelected(LocalTime(timePickerState.hour, timePickerState.minute))
+                }
+            ) {
+                Text(stringResource(GR.strings.ok.resourceId))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(GR.strings.cancel.resourceId))
+            }
+        },
+        text = {
+            TimeInput(state = timePickerState)
+        }
+    )
+}

--- a/core/extensions/src/commonMain/kotlin/net/bradball/teetimecaddie/core/extensions/DateTimeExtensions.kt
+++ b/core/extensions/src/commonMain/kotlin/net/bradball/teetimecaddie/core/extensions/DateTimeExtensions.kt
@@ -19,3 +19,25 @@ fun LocalDate.toEpochMilliseconds(timeZone: TimeZone = TimeZone.currentSystemDef
         .atStartOfDayIn(timeZone)
         .toEpochMilliseconds()
 }
+
+/**
+ * Formats a LocalTime as a 12-hour time string with AM/PM indicator.
+ *
+ * Examples:
+ * - LocalTime(9, 0) -> "9:00 AM"
+ * - LocalTime(14, 30) -> "2:30 PM"
+ * - LocalTime(0, 15) -> "12:15 AM"
+ * - LocalTime(12, 0) -> "12:00 PM"
+ *
+ * @return A formatted time string in "h:mm AM/PM" format.
+ */
+val LocalTime.formattedTime: String
+    get() {
+        val displayHour = when {
+            hour == 0 || hour == 12 -> 12
+            else -> hour % 12
+        }
+        val displayMinute = minute.toString().padStart(2, '0')
+        val amPm = if (hour < 12) "AM" else "PM"
+        return "$displayHour:$displayMinute $amPm"
+    }

--- a/core/models/build.gradle.kts
+++ b/core/models/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             api(libs.mokoresources.api)
             implementation(project(":core:analytics"))
+            implementation(project(":core:extensions"))
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
+++ b/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
@@ -6,6 +6,7 @@ import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlin.time.ExperimentalTime
+import net.bradball.teetimecaddie.core.extensions.formattedTime
 
 /**
  * Represents a single tee time slot with a specific time and number of players.
@@ -36,6 +37,14 @@ data class TeeTime(
      * Returns a short date representation (e.g., "JAN\n15")
      */
     val shortDate: String = "${date.month.name.take(3)}\n${date.day}"
+
+    /**
+     * Returns a comma-separated string of all times in ascending order.
+     * Example: "9:00 AM, 9:10 AM, 9:20 AM"
+     */
+    val formattedTimes: String = times
+        .sortedBy { it.time }
+        .joinToString(", ") { it.time.formattedTime }
 }
 val previewTeeTimeSlot = TeeTimeSlot(
     time = LocalTime(9, 0),

--- a/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
+++ b/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
@@ -25,20 +25,18 @@ data class TeeTime(
     val course: String,
     val date: LocalDate,
     val times: List<TeeTimeSlot>
-)
+) {
 
-/**
- * Returns the total number of players across all time slots.
- */
-val TeeTime.totalPlayers: Int
-    get() = times.sumOf { it.numberOfPlayers }
+    /**
+     * Returns the total number of players across all time slots.
+     */
+    val totalPlayers: Int = times.sumOf { it.numberOfPlayers }
 
-/**
- * Returns a short date representation (e.g., "JAN\n15")
- */
-val TeeTime.shortDate: String
-    get() = "${date.month.name.take(3)}\n${date.dayOfMonth}"
-
+    /**
+     * Returns a short date representation (e.g., "JAN\n15")
+     */
+    val shortDate: String = "${date.month.name.take(3)}\n${date.day}"
+}
 val previewTeeTimeSlot = TeeTimeSlot(
     time = LocalTime(9, 0),
     numberOfPlayers = 4

--- a/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
+++ b/core/models/src/commonMain/kotlin/net/bradball/teetimecaddie/core/models/TeeTime.kt
@@ -7,17 +7,48 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlin.time.ExperimentalTime
 
+/**
+ * Represents a single tee time slot with a specific time and number of players.
+ */
+data class TeeTimeSlot(
+    val time: LocalTime,
+    val numberOfPlayers: Int
+)
+
+/**
+ * Represents a tee time booking that can contain multiple time slots.
+ * This allows groups with multiple foursomes to book consecutive tee times together.
+ */
 data class TeeTime(
     val id: String?,
     val createdBy: String,
     val course: String,
     val date: LocalDate,
-    val time: LocalTime,
-    val numberOfPlayers: Int
+    val times: List<TeeTimeSlot>
 )
 
+/**
+ * Returns the total number of players across all time slots.
+ */
+val TeeTime.totalPlayers: Int
+    get() = times.sumOf { it.numberOfPlayers }
+
+/**
+ * Returns a short date representation (e.g., "JAN\n15")
+ */
 val TeeTime.shortDate: String
     get() = "${date.month.name.take(3)}\n${date.dayOfMonth}"
+
+val previewTeeTimeSlot = TeeTimeSlot(
+    time = LocalTime(9, 0),
+    numberOfPlayers = 4
+)
+
+val previewTeeTimeSlotList = listOf(
+    previewTeeTimeSlot,
+    TeeTimeSlot(time = LocalTime(9, 10), numberOfPlayers = 4),
+    TeeTimeSlot(time = LocalTime(9, 20), numberOfPlayers = 3)
+)
 
 @OptIn(ExperimentalTime::class)
 val previewTeeTime = TeeTime(
@@ -25,13 +56,31 @@ val previewTeeTime = TeeTime(
     createdBy = "Brad",
     course = "Persimmon Ridge",
     date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
-    time = LocalTime(9, 0),
-    numberOfPlayers = 4
+    times = listOf(previewTeeTimeSlot)
 )
 
+@OptIn(ExperimentalTime::class)
 val previewTeeTimeList = listOf(
     previewTeeTime,
-    previewTeeTime,
-    previewTeeTime,
-    previewTeeTime
+    previewTeeTime.copy(
+        id = "previewTime2",
+        times = listOf(
+            TeeTimeSlot(time = LocalTime(10, 0), numberOfPlayers = 4),
+            TeeTimeSlot(time = LocalTime(10, 10), numberOfPlayers = 4)
+        )
+    ),
+    previewTeeTime.copy(
+        id = "previewTime3",
+        times = listOf(
+            TeeTimeSlot(time = LocalTime(11, 0), numberOfPlayers = 3)
+        )
+    ),
+    previewTeeTime.copy(
+        id = "previewTime4",
+        times = listOf(
+            TeeTimeSlot(time = LocalTime(12, 0), numberOfPlayers = 4),
+            TeeTimeSlot(time = LocalTime(12, 10), numberOfPlayers = 4),
+            TeeTimeSlot(time = LocalTime(12, 20), numberOfPlayers = 2)
+        )
+    )
 )

--- a/core/models/src/commonMain/moko-resources/base/strings.xml
+++ b/core/models/src/commonMain/moko-resources/base/strings.xml
@@ -4,4 +4,7 @@
     <string name="error_default_message">We seemed to have shanked one into the woods.</string>
     <string name="error_default_recovery">Take a drop and try again.</string>
     <string name="back">Back</string>
+    <string name="ok">OK</string>
+    <string name="cancel">Cancel</string>
+    <string name="delete">Delete</string>
 </resources>

--- a/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/documents/TeeTimeDocument.kt
+++ b/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/documents/TeeTimeDocument.kt
@@ -4,8 +4,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import net.bradball.teetimecaddie.core.models.TeeTime
-import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 
 /**
  * Document model for storing a single tee time slot in Firestore.
@@ -30,49 +28,4 @@ data class TeeTimeDocument(
 
     @Transient
     var id: String? = null
-}
-
-/**
- * Converts a TeeTimeSlotDocument to a TeeTimeSlot model.
- */
-fun TeeTimeSlotDocument.toModel(): TeeTimeSlot {
-    return TeeTimeSlot(
-        time = time,
-        numberOfPlayers = numberOfPlayers
-    )
-}
-
-/**
- * Converts a TeeTimeSlot model to a TeeTimeSlotDocument for storage.
- */
-fun TeeTimeSlot.toDocument(): TeeTimeSlotDocument {
-    return TeeTimeSlotDocument(
-        time = time,
-        numberOfPlayers = numberOfPlayers
-    )
-}
-
-/**
- * Converts a TeeTimeDocument to a TeeTime model.
- */
-fun TeeTimeDocument.toModel(): TeeTime {
-    return TeeTime(
-        id = id,
-        createdBy = createdBy,
-        course = course,
-        date = date,
-        times = times.map { it.toModel() }.sortedBy { it.time }
-    )
-}
-
-/**
- * Converts a TeeTime model to a TeeTimeDocument for storage.
- */
-fun TeeTime.toDocument(): TeeTimeDocument {
-    return TeeTimeDocument(
-        createdBy = createdBy,
-        course = course,
-        date = date,
-        times = times.map { it.toDocument() }.sortedBy { it.time }
-    )
 }

--- a/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/documents/TeeTimeDocument.kt
+++ b/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/documents/TeeTimeDocument.kt
@@ -1,33 +1,78 @@
 package net.bradbal.teetimecaddie.core.storage.documents
 
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 
+/**
+ * Document model for storing a single tee time slot in Firestore.
+ */
+@Serializable
+data class TeeTimeSlotDocument(
+    val time: LocalTime,
+    val numberOfPlayers: Int
+)
 
+/**
+ * Document model for storing a tee time in Firestore.
+ * Contains a list of time slots, each with its own time and player count.
+ */
 @Serializable
 data class TeeTimeDocument(
     val createdBy: String,
     val course: String,
     val date: LocalDate,
-    val time: LocalTime,
-    val numberOfPlayers: Int
+    val times: List<TeeTimeSlotDocument>
 ) {
 
     @Transient
     var id: String? = null
 }
 
-fun TeeTimeDocument.asModel(): TeeTime {
+/**
+ * Converts a TeeTimeSlotDocument to a TeeTimeSlot model.
+ */
+fun TeeTimeSlotDocument.toModel(): TeeTimeSlot {
+    return TeeTimeSlot(
+        time = time,
+        numberOfPlayers = numberOfPlayers
+    )
+}
+
+/**
+ * Converts a TeeTimeSlot model to a TeeTimeSlotDocument for storage.
+ */
+fun TeeTimeSlot.toDocument(): TeeTimeSlotDocument {
+    return TeeTimeSlotDocument(
+        time = time,
+        numberOfPlayers = numberOfPlayers
+    )
+}
+
+/**
+ * Converts a TeeTimeDocument to a TeeTime model.
+ */
+fun TeeTimeDocument.toModel(): TeeTime {
     return TeeTime(
         id = id,
         createdBy = createdBy,
         course = course,
         date = date,
-        time = time,
-        numberOfPlayers = numberOfPlayers
+        times = times.map { it.toModel() }.sortedBy { it.time }
+    )
+}
+
+/**
+ * Converts a TeeTime model to a TeeTimeDocument for storage.
+ */
+fun TeeTime.toDocument(): TeeTimeDocument {
+    return TeeTimeDocument(
+        createdBy = createdBy,
+        course = course,
+        date = date,
+        times = times.map { it.toDocument() }.sortedBy { it.time }
     )
 }

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimeExtensions.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimeExtensions.kt
@@ -1,0 +1,51 @@
+package net.bradball.teetimecaddie.features.teetimes
+
+import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeDocument
+import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeSlotDocument
+import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+
+/**
+ * Converts a TeeTimeSlotDocument to a TeeTimeSlot model.
+ */
+fun TeeTimeSlotDocument.toModel(): TeeTimeSlot {
+    return TeeTimeSlot(
+        time = time,
+        numberOfPlayers = numberOfPlayers
+    )
+}
+
+/**
+ * Converts a TeeTimeSlot model to a TeeTimeSlotDocument for storage.
+ */
+fun TeeTimeSlot.toDocument(): TeeTimeSlotDocument {
+    return TeeTimeSlotDocument(
+        time = time,
+        numberOfPlayers = numberOfPlayers
+    )
+}
+
+/**
+ * Converts a TeeTimeDocument to a TeeTime model.
+ */
+fun TeeTimeDocument.toModel(): TeeTime {
+    return TeeTime(
+        id = id,
+        createdBy = createdBy,
+        course = course,
+        date = date,
+        times = times.map { it.toModel() }.sortedBy { it.time }
+    )
+}
+
+/**
+ * Converts a TeeTime model to a TeeTimeDocument for storage.
+ */
+fun TeeTime.toDocument(): TeeTimeDocument {
+    return TeeTimeDocument(
+        createdBy = createdBy,
+        course = course,
+        date = date,
+        times = times.map { it.toDocument() }.sortedBy { it.time }
+    )
+}

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.datetime.LocalDate
 import net.bradbal.teetimecaddie.core.storage.TeeTimeStorage
 import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeDocument
 import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeSlotDocument
-import net.bradbal.teetimecaddie.core.storage.documents.toModel
 import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
 import net.bradball.teetimecaddie.core.analytics.EventManager
 import net.bradball.teetimecaddie.core.models.TeeTime

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
@@ -1,17 +1,16 @@
 package net.bradball.teetimecaddie.features.teetimes
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalTime
 import net.bradbal.teetimecaddie.core.storage.TeeTimeStorage
 import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeDocument
-import net.bradbal.teetimecaddie.core.storage.documents.asModel
+import net.bradbal.teetimecaddie.core.storage.documents.TeeTimeSlotDocument
+import net.bradbal.teetimecaddie.core.storage.documents.toModel
 import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
 import net.bradball.teetimecaddie.core.analytics.EventManager
 import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import kotlin.coroutines.cancellation.CancellationException
 
 class TeeTimesRepository(
@@ -19,34 +18,44 @@ class TeeTimesRepository(
     private val teeTimeStorage: TeeTimeStorage
 ) {
 
+    /**
+     * Creates a new tee time with multiple time slots.
+     *
+     * @param createdBy The ID of the player creating the tee time.
+     * @param course The name of the golf course.
+     * @param date The date of the tee time.
+     * @param times A list of time slots, each containing a time and number of players.
+     *              Times will be stored in ascending order.
+     * @return The created TeeTime with its assigned ID.
+     */
     @Throws(CancellationException::class)
     suspend fun createTeeTime(
         createdBy: String,
         course: String,
         date: LocalDate,
-        time: LocalTime,
-        numberOfPlayers: Int
+        times: List<TeeTimeSlot>
     ): TeeTime {
         eventManager.logEvent(AnalyticsEvent.AddTeeTime)
 
+        val sortedTimes = times.sortedBy { it.time }
         val doc = TeeTimeDocument(
             createdBy = createdBy,
             course = course,
             date = date,
-            time = time,
-            numberOfPlayers = numberOfPlayers
+            times = sortedTimes.map { slot ->
+                TeeTimeSlotDocument(
+                    time = slot.time,
+                    numberOfPlayers = slot.numberOfPlayers
+                )
+            }
         )
         doc.id = teeTimeStorage.addTeeTime(doc)
-        return doc.asModel()
+        return doc.toModel()
     }
 
     fun getTeeTimes(player: String): Flow<List<TeeTime>> = teeTimeStorage
         .teeTimesFlow(player)
         .mapLatest { list ->
-            list.map {
-                it.asModel()
-            }
+            list.map { it.toModel() }
         }
-
-    fun test(): Int = 1
 }

--- a/features/teetimes/src/commonMain/moko-resources/base/strings.xml
+++ b/features/teetimes/src/commonMain/moko-resources/base/strings.xml
@@ -10,4 +10,10 @@
     <string name="field_Label_Time">Time</string>
     <string name="field_Label_Players">Number of Players</string>
     <string name="button_create">Create</string>
+
+    <!-- Multiple tee times -->
+    <string name="tee_times_section_header">Tee Times</string>
+    <string name="add_time_button">Add Time</string>
+    <string name="players_label">Players</string>
+    <string name="validation_at_least_one_time">At least one tee time is required</string>
 </resources>

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
@@ -22,26 +22,40 @@ struct AddTeeTimeScreen: View {
     var selectedDate: Date = Date()
 
     @State
-    var selectedTime: Date = Date()
+    private var showTimePicker: Bool = false
 
     @State
-    var players: Int = 4
+    private var selectedTimeForPicker: Date = Calendar.current.date(
+        bySettingHour: 9,
+        minute: 0,
+        second: 0,
+        of: Date()
+    ) ?? Date()
 
     var body: some View {
         Screen(AnalyticsScreen.AddTeeTime(viewName: self.viewName)) {
             AddTeeTimeContent(
                 courseName: $courseName,
                 selectedDate: $selectedDate,
-                selectedTime: $selectedTime,
-                players: $players,
+                timeSlots: viewModel.timeSlots,
                 isLoading: viewModel.showLoadingProgress,
+                onAddTimeClick: { showTimePicker = true },
+                onUpdatePlayerCount: viewModel.updatePlayerCount,
                 onSave: {
                     viewModel.saveTeeTime(
                         courseName: courseName,
-                        selectedDate: selectedDate,
-                        selectedTime: selectedTime,
-                        numberOfPlayers: players
+                        selectedDate: selectedDate
                     )
+                }
+            )
+        }
+        .sheet(isPresented: $showTimePicker) {
+            TimePickerSheet(
+                selectedTime: $selectedTimeForPicker,
+                onCancel: { showTimePicker = false },
+                onConfirm: {
+                    viewModel.addTimeSlot(time: selectedTimeForPicker)
+                    showTimePicker = false
                 }
             )
         }
@@ -53,13 +67,20 @@ struct AddTeeTimeScreen: View {
     }
 }
 
+// MARK: - Content View
+
 fileprivate struct AddTeeTimeContent: View {
     @Binding var courseName: String
     @Binding var selectedDate: Date
-    @Binding var selectedTime: Date
-    @Binding var players: Int
+    let timeSlots: [TeeTimeSlot]
     let isLoading: Bool
+    let onAddTimeClick: () -> Void
+    let onUpdatePlayerCount: (LocalTime, Int) -> Void
     let onSave: () -> Void
+
+    private var canSave: Bool {
+        !courseName.isEmpty && !timeSlots.isEmpty
+    }
 
     var body: some View {
         ScrollView {
@@ -77,37 +98,13 @@ fileprivate struct AddTeeTimeContent: View {
                 )
                 .padding(.horizontal)
 
-                // Time Picker
-                DatePicker(
-                    TTR.strings().field_Label_Time.desc().localized(),
-                    selection: $selectedTime,
-                    displayedComponents: .hourAndMinute
+                // Tee Times Section
+                TeeTimesSection(
+                    timeSlots: timeSlots,
+                    onAddTimeClick: onAddTimeClick,
+                    onUpdatePlayerCount: onUpdatePlayerCount
                 )
                 .padding(.horizontal)
-
-                // Number of Players Slider
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(TTR.strings().field_Label_Players.desc().localized())
-                        .font(.body)
-                        .padding(.horizontal)
-
-                    HStack {
-                        Slider(
-                            value: Binding(
-                                get: { Double(players) },
-                                set: { players = Int($0) }
-                            ),
-                            in: 1...4,
-                            step: 1
-                        )
-                        .padding(.leading)
-
-                        Text("\(players)")
-                            .font(.headline)
-                            .frame(width: 40)
-                            .padding(.trailing)
-                    }
-                }
 
                 Spacer()
                     .frame(height: 32)
@@ -115,13 +112,131 @@ fileprivate struct AddTeeTimeContent: View {
                 // Save Button
                 LoadingButton(TTR.strings().button_create.desc().localized(), isLoading: isLoading, action: onSave)
                     .buttonStyle(.Filled)
+                    .disabled(!canSave)
             }
             .padding(.vertical)
         }
     }
 }
 
-#Preview {
+// MARK: - Tee Times Section
+
+fileprivate struct TeeTimesSection: View {
+    let timeSlots: [TeeTimeSlot]
+    let onAddTimeClick: () -> Void
+    let onUpdatePlayerCount: (LocalTime, Int) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Section Header
+            Text(TTR.strings().tee_times_section_header.desc().localized())
+                .font(.headline)
+
+            // List of time slots
+            ForEach(timeSlots, id: \.time) { slot in
+                TimeSlotRow(
+                    slot: slot,
+                    onUpdatePlayerCount: { players in
+                        onUpdatePlayerCount(slot.time, players)
+                    }
+                )
+                Divider()
+            }
+
+            // Add Time Button
+            Button(action: onAddTimeClick) {
+                HStack {
+                    Image(systemName: "plus")
+                    Text(TTR.strings().add_time_button.desc().localized())
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+// MARK: - Time Slot Row
+
+fileprivate struct TimeSlotRow: View {
+    let slot: TeeTimeSlot
+    let onUpdatePlayerCount: (Int) -> Void
+
+    private var formattedTime: String {
+        let hour = slot.time.hour
+        let minute = slot.time.minute
+        let displayHour = hour == 0 || hour == 12 ? 12 : hour % 12
+        let amPm = hour < 12 ? "AM" : "PM"
+        return String(format: "%d:%02d %@", displayHour, minute, amPm)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Time display
+            Text(formattedTime)
+                .font(.headline)
+
+            // Player count slider
+            HStack {
+                Text(TTR.strings().players_label.desc().localized())
+                    .font(.body)
+
+                Slider(
+                    value: Binding(
+                        get: { Double(slot.numberOfPlayers) },
+                        set: { onUpdatePlayerCount(Int($0)) }
+                    ),
+                    in: 1...4,
+                    step: 1
+                )
+
+                Text("\(slot.numberOfPlayers)")
+                    .font(.headline)
+                    .frame(width: 30)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Time Picker Sheet
+
+fileprivate struct TimePickerSheet: View {
+    @Binding var selectedTime: Date
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            DatePicker(
+                "",
+                selection: $selectedTime,
+                displayedComponents: .hourAndMinute
+            )
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .navigationTitle(TTR.strings().field_Label_Time.desc().localized())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(GR.strings().cancel.desc().localized()) {
+                        onCancel()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(GR.strings().ok.desc().localized()) {
+                        onConfirm()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Empty") {
     TeeTimeCaddieTheme {
         NavigationStack {
             AddTeeTimeScreen(
@@ -131,5 +246,32 @@ fileprivate struct AddTeeTimeContent: View {
             .navigationTitle(TTR.strings().add_tee_time.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
         }
+    }
+}
+
+#Preview("With Times") {
+    TeeTimeCaddieTheme {
+        NavigationStack {
+            AddTeeTimeContentPreviewWrapper()
+                .navigationTitle(TTR.strings().add_tee_time.desc().localized())
+                .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+fileprivate struct AddTeeTimeContentPreviewWrapper: View {
+    @State var courseName: String = "Persimmon Ridge"
+    @State var selectedDate: Date = Date()
+
+    var body: some View {
+        AddTeeTimeContent(
+            courseName: $courseName,
+            selectedDate: $selectedDate,
+            timeSlots: TeeTimeKt.previewTeeTimeSlotList,
+            isLoading: false,
+            onAddTimeClick: {},
+            onUpdatePlayerCount: { _, _ in },
+            onSave: {}
+        )
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
@@ -162,18 +162,10 @@ fileprivate struct TimeSlotRow: View {
     let slot: TeeTimeSlot
     let onUpdatePlayerCount: (Int) -> Void
 
-    private var formattedTime: String {
-        let hour = slot.time.hour
-        let minute = slot.time.minute
-        let displayHour = hour == 0 || hour == 12 ? 12 : hour % 12
-        let amPm = hour < 12 ? "AM" : "PM"
-        return String(format: "%d:%02d %@", displayHour, minute, amPm)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            // Time display
-            Text(formattedTime)
+            // Time display - uses the shared formattedTime property from KMP
+            Text(slot.time.formattedTime)
                 .font(.headline)
 
             // Player count slider

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
@@ -17,6 +17,9 @@ class AddTeeTimeViewModel {
     private(set) var showLoadingProgress: Bool = false
     private(set) var saveSuccess: Bool = false
 
+    /// List of tee time slots, sorted by time
+    private(set) var timeSlots: [TeeTimeSlot] = []
+
     init(
         teeTimesRepo: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
         authRepo: AuthRepository = AuthModule.shared.authRepository()
@@ -25,26 +28,56 @@ class AddTeeTimeViewModel {
         self.authRepo = authRepo
     }
 
-    func saveTeeTime(courseName: String, selectedDate: Date, selectedTime: Date, numberOfPlayers: Int) {
-        
-        guard !courseName.isEmpty, numberOfPlayers > 0, selectedDate >= Date() else {
+    /// Adds a new time slot with the default number of players (4).
+    /// If the time already exists in the list, it will not be added.
+    /// - Parameter time: The time to add (as a Date).
+    /// - Returns: true if the time was added, false if it already existed.
+    @discardableResult
+    func addTimeSlot(time: Date) -> Bool {
+        let localTime = time.toLocalTime()
+
+        // Check if time already exists
+        if timeSlots.contains(where: { $0.time == localTime }) {
+            return false
+        }
+
+        let newSlot = TeeTimeSlot(time: localTime, numberOfPlayers: 4)
+        timeSlots.append(newSlot)
+        timeSlots.sort { compareLocalTime($0.time, $1.time) }
+        return true
+    }
+
+    /// Updates the number of players for a specific time slot.
+    /// - Parameters:
+    ///   - time: The LocalTime of the slot to update.
+    ///   - numberOfPlayers: The new number of players (1-4).
+    func updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        guard let index = timeSlots.firstIndex(where: { $0.time == time }) else { return }
+        let clampedPlayers = min(max(numberOfPlayers, 1), 4)
+        timeSlots[index] = TeeTimeSlot(time: time, numberOfPlayers: Int32(clampedPlayers))
+    }
+
+    /// Saves the tee time with all added time slots.
+    /// - Parameters:
+    ///   - courseName: The name of the golf course.
+    ///   - selectedDate: The date of the tee time.
+    func saveTeeTime(courseName: String, selectedDate: Date) {
+        guard !courseName.isEmpty, !timeSlots.isEmpty else {
             return
         }
-                    
+
         Task {
             showLoadingProgress = true
             defer { showLoadingProgress = false }
 
             do {
                 let localDate = selectedDate.toLocalDate()
-                let localTime = selectedTime.toLocalTime()
 
                 _ = try await teeTimesRepo.createTeeTime(
                     createdBy: authRepo.currentUser.id,
                     course: courseName,
                     date: localDate,
-                    time: localTime,
-                    numberOfPlayers: Int32(numberOfPlayers)
+                    times: timeSlots
                 )
 
                 saveSuccess = true
@@ -57,7 +90,7 @@ class AddTeeTimeViewModel {
 }
 
 // MARK: - Date Conversion Extensions
-private extension Date {
+extension Date {
     func toLocalDate() -> LocalDate {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month, .day], from: self)
@@ -78,4 +111,15 @@ private extension Date {
             nanosecond: 0
         )
     }
+}
+
+// MARK: - LocalTime Comparison Helper
+
+/// Compares two LocalTime values for sorting purposes.
+/// Returns true if the first time is before the second time.
+func compareLocalTime(_ lhs: LocalTime, _ rhs: LocalTime) -> Bool {
+    if lhs.hour != rhs.hour {
+        return lhs.hour < rhs.hour
+    }
+    return lhs.minute < rhs.minute
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
@@ -43,7 +43,7 @@ class AddTeeTimeViewModel {
 
         let newSlot = TeeTimeSlot(time: localTime, numberOfPlayers: 4)
         timeSlots.append(newSlot)
-        timeSlots.sort { compareLocalTime($0.time, $1.time) }
+        timeSlots.sort { $0.time.compareTo(other: $1.time) < 0 }
         return true
     }
 
@@ -113,13 +113,3 @@ extension Date {
     }
 }
 
-// MARK: - LocalTime Comparison Helper
-
-/// Compares two LocalTime values for sorting purposes.
-/// Returns true if the first time is before the second time.
-func compareLocalTime(_ lhs: LocalTime, _ rhs: LocalTime) -> Bool {
-    if lhs.hour != rhs.hour {
-        return lhs.hour < rhs.hour
-    }
-    return lhs.minute < rhs.minute
-}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
@@ -36,7 +36,7 @@ struct TeeTimeRow: View {
                         .frame(width: 16, height: 16)
                         .foregroundColor(.secondary)
 
-                    Text(formattedTime)
+                    Text(formattedTimes)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                 }
@@ -44,14 +44,14 @@ struct TeeTimeRow: View {
 
             Spacer()
 
-            // Player count (right)
+            // Total player count (right)
             HStack(spacing: 4) {
                 Image(.teeEmpty)
                     .resizable()
                     .frame(width: 20, height: 20)
                     .foregroundColor(.accentColor)
 
-                Text("\(teeTime.numberOfPlayers)")
+                Text("\(teeTime.totalPlayers)")
                     .font(.headline)
             }
         }
@@ -74,10 +74,16 @@ struct TeeTimeRow: View {
         return "\(monthName) \(teeTime.date.day)"
     }
 
-    private var formattedTime: String {
-        let hour = teeTime.time.hour == 0 ? 12 : (teeTime.time.hour > 12 ? teeTime.time.hour - 12 : teeTime.time.hour)
-        let minute = String(format: "%02d", teeTime.time.minute)
-        let amPm = teeTime.time.hour < 12 ? "AM" : "PM"
+    private var formattedTimes: String {
+        // Sort times and format each one
+        let sortedSlots = teeTime.times.sorted { compareLocalTime($0.time, $1.time) }
+        return sortedSlots.map { formatTime($0.time) }.joined(separator: ", ")
+    }
+
+    private func formatTime(_ time: LocalTime) -> String {
+        let hour = time.hour == 0 || time.hour == 12 ? 12 : Int(time.hour) % 12
+        let minute = String(format: "%02d", time.minute)
+        let amPm = time.hour < 12 ? "AM" : "PM"
         return "\(hour):\(minute) \(amPm)"
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
@@ -36,7 +36,8 @@ struct TeeTimeRow: View {
                         .frame(width: 16, height: 16)
                         .foregroundColor(.secondary)
 
-                    Text(formattedTimes)
+                    // Uses the shared formattedTimes property from KMP
+                    Text(teeTime.formattedTimes)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                 }
@@ -74,18 +75,6 @@ struct TeeTimeRow: View {
         return "\(monthName) \(teeTime.date.day)"
     }
 
-    private var formattedTimes: String {
-        // Sort times and format each one
-        let sortedSlots = teeTime.times.sorted { compareLocalTime($0.time, $1.time) }
-        return sortedSlots.map { formatTime($0.time) }.joined(separator: ", ")
-    }
-
-    private func formatTime(_ time: LocalTime) -> String {
-        let hour = time.hour == 0 || time.hour == 12 ? 12 : Int(time.hour) % 12
-        let minute = String(format: "%02d", time.minute)
-        let amPm = time.hour < 12 ? "AM" : "PM"
-        return "\(hour):\(minute) \(amPm)"
-    }
 }
 
 // Extension to convert Kotlin LocalDate to Swift Date


### PR DESCRIPTION
## Summary
- Allows tee times to have multiple time slots, each with its own player count (1-4)
- Groups with multiple foursomes can now book consecutive tee times together
- Times displayed in ascending order in both Add Tee Time screen and Tee Times List

## Changes
### Shared KMP SDK
- Created `TeeTimeSlot` data class with time and numberOfPlayers
- Updated `TeeTime` to use `times: List<TeeTimeSlot>` instead of single time/players
- Added `totalPlayers` extension property to calculate sum across all slots
- Updated `TeeTimeDocument` and storage layer for Firestore persistence
- Updated `TeeTimesRepository.createTeeTime()` to accept list of time slots
- Added string resources for new UI components

### Android
- Redesigned Add Tee Time screen with "Tee Times" section
- Added time slot list with player count sliders (1-4)
- Time picker dialog for adding new times
- Duplicate time prevention
- Updated TeeTimeCard to show all times and total player count

### iOS
- Redesigned Add Tee Time screen with time slots section
- Time picker sheet for adding new times
- Player count sliders for each time slot
- Added LocalTime comparison helper for sorting
- Updated TeeTimeRow to show all times and total player count

## Test Plan
- [x] Add tee time with single time slot - verify displays correctly
- [x] Add tee time with multiple time slots - verify all times shown in order
- [x] Verify player count slider adjusts 1-4 for each slot
- [x] Verify duplicate times cannot be added
- [x] Verify tee times list shows all times and total players
- [x] Build and verify both Android and iOS platforms

## Related Story
[TTC-40: Add Multiple times to a Tee Time](https://bradball.atlassian.net/browse/TTC-40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)