### PR TITLE
TTC-51: Remove a Time during Tee Time creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,16 +431,16 @@ Follow all of the Steps in the sections below for EVERY Jira Issue that you impl
 1. Plan the work to be done:
    1. Read the full Issue, including Acceptance Criteria and Notes. 
    2. Make sure the Issue has proper sub-tasks:
-      a. If the Issue already has sub-tasks, read them to understand what to do and how to complete the implementation.
+      - If the Issue already has sub-tasks, read them to understand what to do and how to complete the implementation.
          - If the sub-tasks are not sufficient to complete the story, follow the rest of these instructions to complete the task list.
-     b. If the Issue does not have sub-tasks (or if the tasks aren't enough to fully implement the story):
+      - If the Issue does not have sub-tasks (or if the tasks aren't enough to fully implement the story):
         - Add appropriate sub-tasks to the Issue so that you or others can complete the Issue.
           - Keep sub-tasks fairly high level. Prefer defining 5-10 broad tasks to complete an Issue, instead of 20+ detailed tasks.
           - Tasks can have a list of steps in the task list if you want to provide detailed instructions for a task. However, this is not optional, not required.
-     c. Ask me to check and verify the sub-tasks before continuing.
-   3. Assign the Issue to yourself, and move it to the IN-PROGRESS step/column in Jira.
-   4. Ensure that the necessary git branches are setup, according to the "Branch Strategy" and "Workflow for Jira Issue Development" guidelines in the "Working with Github" section of this document.
-      a. If there are uncommited changes on the current branch, ask me what to do before continuing.
+2. **CHECKPOINT: Ask the user to check and verify the sub-tasks before continuing.**
+3. Assign the Issue to yourself, and move it to the IN-PROGRESS step/column in Jira.
+4. Ensure that the necessary git branches are setup, according to the "Branch Strategy" and "Workflow for Jira Issue Development" guidelines in the "Working with Github" section of this document.
+      - If there are uncommited changes on the current branch, ask me what to do before continuing.
 
 ## Writing Code to Implement the Issue
 

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeScreen.kt
@@ -67,6 +67,7 @@ fun AddTeeTimeScreen(
         onAddTimeClick = viewModel::onAddTimeClick,
         onAddTimeSlot = viewModel::addTimeSlot,
         onUpdatePlayerCount = viewModel::updatePlayerCount,
+        onRemoveTimeSlot = viewModel::removeTimeSlot,
         onSaveClick = viewModel::saveTeeTime,
         onBackClick = onBack
     )
@@ -80,6 +81,7 @@ private fun AddTeeTimeContent(
     onAddTimeClick: () -> Unit,
     onAddTimeSlot: (LocalTime) -> Boolean,
     onUpdatePlayerCount: (LocalTime, Int) -> Unit,
+    onRemoveTimeSlot: (LocalTime) -> Unit,
     onSaveClick: (String, LocalDate?) -> Unit,
     onBackClick: () -> Unit
 ) {
@@ -128,7 +130,8 @@ private fun AddTeeTimeContent(
                     onAddTimeClick()
                     showTimePickerDialog = true
                 },
-                onUpdatePlayerCount = onUpdatePlayerCount
+                onUpdatePlayerCount = onUpdatePlayerCount,
+                onRemoveTimeSlot = onRemoveTimeSlot
             )
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -160,7 +163,8 @@ private fun AddTeeTimeContent(
 private fun TeeTimesSection(
     timeSlots: List<TeeTimeSlot>,
     onAddTimeClick: () -> Unit,
-    onUpdatePlayerCount: (LocalTime, Int) -> Unit
+    onUpdatePlayerCount: (LocalTime, Int) -> Unit,
+    onRemoveTimeSlot: (LocalTime) -> Unit
 ) {
     Column {
         // Section Header
@@ -176,7 +180,8 @@ private fun TeeTimesSection(
             timeSlots.forEach { slot ->
                 TimeSlotRow(
                     slot = slot,
-                    onUpdatePlayerCount = { players -> onUpdatePlayerCount(slot.time, players) }
+                    onUpdatePlayerCount = { players -> onUpdatePlayerCount(slot.time, players) },
+                    onRemove = { onRemoveTimeSlot(slot.time) }
                 )
                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
             }
@@ -200,16 +205,27 @@ private fun TeeTimesSection(
 @Composable
 private fun TimeSlotRow(
     slot: TeeTimeSlot,
-    onUpdatePlayerCount: (Int) -> Unit
+    onUpdatePlayerCount: (Int) -> Unit,
+    onRemove: () -> Unit
 ) {
     Column {
-        // Time display
-        Text(
-            text = slot.time.formattedTime,
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
+        // Time display with trash icon
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = slot.time.formattedTime,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onRemove) {
+                Icon(
+                    TtcIcons.TRASH.painter,
+                    contentDescription = stringResource(GR.strings.delete.resourceId),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
 
         // Player count slider
         Row(
@@ -246,6 +262,7 @@ private fun AddTeeTimeContentPreview() {
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
+            onRemoveTimeSlot = { },
             onSaveClick = { _, _ -> },
             onBackClick = { }
         )
@@ -262,6 +279,7 @@ private fun AddTeeTimeContentWithTimesPreview() {
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
+            onRemoveTimeSlot = { },
             onSaveClick = { _, _ -> },
             onBackClick = { }
         )

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/addTeeTime/AddTeeTimeViewModel.kt
@@ -74,11 +74,12 @@ class AddTeeTimeViewModel @Inject constructor(
     }
 
     /**
-     * Removes a time slot from the list.
+     * Removes a time slot from the list and logs the analytics event.
      *
      * @param time The time of the slot to remove.
      */
     fun removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(AnalyticsEvent.RemoveTimeClick)
         _timeSlots.removeAll { it.time == time }
     }
 

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/icons/TtcIcons.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/icons/TtcIcons.kt
@@ -14,6 +14,7 @@ enum class TtcIcons(val resource: Int) {
     TEE(R.drawable.icon_tee),
     TEE_CLOCK(R.drawable.icon_tee_clock),
     TEE_STRIKE(R.drawable.icon_strikethrough),
+    TRASH(R.drawable.icon_trash),
     VISIBILITY(R.drawable.icon_visibility),
     VISIBILITY_OFF(R.drawable.icon_visibility_off);
 

--- a/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
@@ -79,6 +79,8 @@ sealed class AnalyticsEvent(val name: String, internal val type: EventType) {
     object AddTime: AnalyticsEvent("add_time", EventType.OPERATION)
     @Serializable
     data class NumberOfPlayersClick(val numberOfPlayers: Int): AnalyticsEvent("number_of_players_click", EventType.CLICK)
+    @Serializable
+    object RemoveTimeClick: AnalyticsEvent("remove_time_click", EventType.CLICK)
 
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeScreen.swift
@@ -44,6 +44,7 @@ struct AddTeeTimeScreen: View {
                     showTimePicker = true
                 },
                 onUpdatePlayerCount: viewModel.updatePlayerCount,
+                onRemoveTimeSlot: viewModel.removeTimeSlot,
                 onSave: {
                     viewModel.saveTeeTime(
                         courseName: courseName,
@@ -79,6 +80,7 @@ fileprivate struct AddTeeTimeContent: View {
     let isLoading: Bool
     let onAddTimeClick: () -> Void
     let onUpdatePlayerCount: (LocalTime, Int) -> Void
+    let onRemoveTimeSlot: (LocalTime) -> Void
     let onSave: () -> Void
 
     private var canSave: Bool {
@@ -105,7 +107,8 @@ fileprivate struct AddTeeTimeContent: View {
                 TeeTimesSection(
                     timeSlots: timeSlots,
                     onAddTimeClick: onAddTimeClick,
-                    onUpdatePlayerCount: onUpdatePlayerCount
+                    onUpdatePlayerCount: onUpdatePlayerCount,
+                    onRemoveTimeSlot: onRemoveTimeSlot
                 )
                 .padding(.horizontal)
 
@@ -128,6 +131,7 @@ fileprivate struct TeeTimesSection: View {
     let timeSlots: [TeeTimeSlot]
     let onAddTimeClick: () -> Void
     let onUpdatePlayerCount: (LocalTime, Int) -> Void
+    let onRemoveTimeSlot: (LocalTime) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -141,6 +145,9 @@ fileprivate struct TeeTimesSection: View {
                     slot: slot,
                     onUpdatePlayerCount: { players in
                         onUpdatePlayerCount(slot.time, players)
+                    },
+                    onRemove: {
+                        onRemoveTimeSlot(slot.time)
                     }
                 )
                 Divider()
@@ -164,12 +171,24 @@ fileprivate struct TeeTimesSection: View {
 fileprivate struct TimeSlotRow: View {
     let slot: TeeTimeSlot
     let onUpdatePlayerCount: (Int) -> Void
+    let onRemove: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            // Time display - uses the shared formattedTime property from KMP
-            Text(slot.time.formattedTime)
-                .font(.headline)
+            // Time display with trash icon
+            HStack {
+                Text(slot.time.formattedTime)
+                    .font(.headline)
+
+                Spacer()
+
+                Button(action: onRemove) {
+                    Image("icons/trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(GR.strings().delete.desc().localized())
+            }
 
             // Player count slider
             HStack {
@@ -266,6 +285,7 @@ fileprivate struct AddTeeTimeContentPreviewWrapper: View {
             isLoading: false,
             onAddTimeClick: {},
             onUpdatePlayerCount: { _, _ in },
+            onRemoveTimeSlot: { _ in },
             onSave: {}
         )
     }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
@@ -67,6 +67,13 @@ class AddTeeTimeViewModel {
         eventManager.logEvent(event: AnalyticsEvent.NumberOfPlayersClick(numberOfPlayers: Int32(clampedPlayers)))
     }
 
+    /// Removes a time slot from the list and logs the analytics event.
+    /// - Parameter time: The LocalTime of the slot to remove.
+    func removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(event: AnalyticsEvent.RemoveTimeClick())
+        timeSlots.removeAll { $0.time == time }
+    }
+
     /// Saves the tee time with all added time slots.
     /// - Parameters:
     ///   - courseName: The name of the golf course.


### PR DESCRIPTION
## Summary
- Add trash icon next to each time slot on the Add Tee Time screen (Android & iOS)
- Clicking the trash icon removes the time slot from the list
- Fires `remove_time_click` analytics event when trash icon is clicked
- Create button automatically disables when all times are removed (existing behavior)

## Changes
- **KMP**: Added `RemoveTimeClick` analytics event to `AnalyticsEvent` sealed class
- **Android**: 
  - Added TRASH icon to TtcIcons enum
  - Updated AddTeeTimeScreen to display trash icon in TimeSlotRow
  - Updated AddTeeTimeViewModel to log analytics when removing time slots
- **iOS**:
  - Updated AddTeeTimeScreen to display trash icon in TimeSlotRow  
  - Added removeTimeSlot method to AddTeeTimeViewModel with analytics logging

## Test plan
- [x] Android build succeeds
- [x] iOS build succeeds
- [x] Unit tests pass
- [ ] Manual test: Add multiple times, remove one, verify it disappears
- [ ] Manual test: Remove all times, verify Create button disables
- [ ] Manual test: Verify analytics event fires on removal

## Related Story
[TTC-51: Remove a Time during Tee Time creation](https://bradleycorn.atlassian.net/browse/TTC-51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)