### PR TITLE
Edit Test 2

### DIFF
--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TeeTimeFormComponents.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TeeTimeFormComponents.kt
@@ -1,0 +1,164 @@
+package net.bradball.teetimecaddie.android.feature.teeTimes.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalTime
+import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
+import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
+import net.bradball.teetimecaddie.core.extensions.formattedTime
+import net.bradball.teetimecaddie.core.models.GR
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
+import net.bradball.teetimecaddie.features.teetimes.TTR
+
+/**
+ * A section displaying the list of tee time slots with an "Add Time" button.
+ *
+ * @param timeSlots The list of time slots to display.
+ * @param onAddTimeClick Called when the "Add Time" button is clicked.
+ * @param onUpdatePlayerCount Called when the player count slider changes for a time slot.
+ * @param onRemoveTimeSlot Called when a time slot is removed.
+ */
+@Composable
+fun TeeTimesSection(
+    timeSlots: List<TeeTimeSlot>,
+    onAddTimeClick: () -> Unit,
+    onUpdatePlayerCount: (LocalTime, Int) -> Unit,
+    onRemoveTimeSlot: (LocalTime) -> Unit
+) {
+    Column {
+        // Section Header
+        Text(
+            text = stringResource(TTR.strings.tee_times_section_header.resourceId),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // List of time slots
+        if (timeSlots.isNotEmpty()) {
+            timeSlots.forEach { slot ->
+                TimeSlotRow(
+                    slot = slot,
+                    onUpdatePlayerCount = { players -> onUpdatePlayerCount(slot.time, players) },
+                    onRemove = { onRemoveTimeSlot(slot.time) }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            }
+        }
+
+        // Add Time Button
+        OutlinedButton(
+            onClick = onAddTimeClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(
+                TtcIcons.ADD.painter,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Text(stringResource(TTR.strings.add_time_button.resourceId))
+        }
+    }
+}
+
+/**
+ * A row displaying a single time slot with time, player count slider, and remove button.
+ *
+ * @param slot The time slot to display.
+ * @param onUpdatePlayerCount Called when the player count slider changes.
+ * @param onRemove Called when the remove button is clicked.
+ */
+@Composable
+fun TimeSlotRow(
+    slot: TeeTimeSlot,
+    onUpdatePlayerCount: (Int) -> Unit,
+    onRemove: () -> Unit
+) {
+    Column {
+        // Time display with trash icon
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = slot.time.formattedTime,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onRemove) {
+                Icon(
+                    TtcIcons.TRASH.painter,
+                    contentDescription = stringResource(GR.strings.delete.resourceId),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        // Player count slider
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(TTR.strings.players_label.resourceId),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Slider(
+                value = slot.numberOfPlayers.toFloat(),
+                onValueChange = { onUpdatePlayerCount(it.toInt()) },
+                valueRange = 1f..4f,
+                steps = 2,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = slot.numberOfPlayers.toString(),
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TeeTimesSectionEmptyPreview() {
+    MyApplicationTheme {
+        TeeTimesSection(
+            timeSlots = emptyList(),
+            onAddTimeClick = { },
+            onUpdatePlayerCount = { _, _ -> },
+            onRemoveTimeSlot = { }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TeeTimesSectionWithTimesPreview() {
+    MyApplicationTheme {
+        TeeTimesSection(
+            timeSlots = previewTeeTimeSlotList,
+            onAddTimeClick = { },
+            onUpdatePlayerCount = { _, _ -> },
+            onRemoveTimeSlot = { }
+        )
+    }
+}

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
@@ -1,4 +1,4 @@
-package net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime
+package net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -25,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.feature.teeTimes.common.TeeTimesSection
@@ -37,26 +36,39 @@ import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.android.ui.common.rememberTtcDatePickerState
 import net.bradball.teetimecaddie.android.ui.common.selectedDate
 import net.bradball.teetimecaddie.core.models.GR
+import net.bradball.teetimecaddie.core.models.TeeTime
 import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
 import net.bradball.teetimecaddie.features.teetimes.TTR
 
 @Composable
-fun AddTeeTimeScreen(
+fun EditTeeTimeScreen(
+    teeTime: TeeTime,
+    viewModel: EditTeeTimeViewModel,
     onBack: () -> Unit,
-    onTeeTimeCreated: () -> Unit,
-    viewModel: AddTeeTimeViewModel = hiltViewModel()
+    onTeeTimeSaved: () -> Unit
 ) {
+    // Initialize ViewModel with tee time data
+    LaunchedEffect(teeTime) {
+        viewModel.initialize(teeTime)
+    }
+
     // Handle save success
     LaunchedEffect(viewModel.saveSuccess) {
         if (viewModel.saveSuccess) {
-            onTeeTimeCreated()
+            onTeeTimeSaved()
         }
     }
 
-    AddTeeTimeContent(
+    EditTeeTimeContent(
         showLoadingProgress = viewModel.showLoadingProgress,
+        courseName = viewModel.courseName,
+        initialDate = viewModel.selectedDate,
         timeSlots = viewModel.timeSlots,
+        hasChanges = viewModel.hasChanges,
+        onCourseNameChange = viewModel::updateCourseName,
+        onDateChange = viewModel::updateDate,
         onAddTimeClick = viewModel::onAddTimeClick,
         onAddTimeSlot = viewModel::addTimeSlot,
         onUpdatePlayerCount = viewModel::updatePlayerCount,
@@ -68,24 +80,38 @@ fun AddTeeTimeScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AddTeeTimeContent(
+private fun EditTeeTimeContent(
     showLoadingProgress: Boolean,
+    courseName: String,
+    initialDate: LocalDate?,
     timeSlots: List<TeeTimeSlot>,
+    hasChanges: Boolean,
+    onCourseNameChange: (String) -> Unit,
+    onDateChange: (LocalDate?) -> Unit,
     onAddTimeClick: () -> Unit,
     onAddTimeSlot: (LocalTime) -> Boolean,
     onUpdatePlayerCount: (LocalTime, Int) -> Unit,
     onRemoveTimeSlot: (LocalTime) -> Unit,
-    onSaveClick: (String, LocalDate?) -> Unit,
+    onSaveClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    var courseName by remember { mutableStateOf("") }
-    val date = rememberTtcDatePickerState()
+    val date = rememberTtcDatePickerState(initialDate)
     var showTimePickerDialog by remember { mutableStateOf(false) }
+
+    // Sync date picker state with ViewModel
+    LaunchedEffect(date.selectedDate) {
+        onDateChange(date.selectedDate)
+    }
+
+    val canSave = courseName.isNotBlank() &&
+            date.selectedDate != null &&
+            timeSlots.isNotEmpty() &&
+            hasChanges
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(TTR.strings.add_tee_time.resourceId)) },
+                title = { Text(stringResource(TTR.strings.edit_tee_time.resourceId)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(TtcIcons.ARROW_BACK.painter, contentDescription = stringResource(GR.strings.back.resourceId))
@@ -104,7 +130,7 @@ private fun AddTeeTimeContent(
             // Course Name TextField
             OutlinedTextField(
                 value = courseName,
-                onValueChange = { courseName = it },
+                onValueChange = onCourseNameChange,
                 label = { Text(stringResource(TTR.strings.field_label_course_name.resourceId)) },
                 modifier = Modifier.fillMaxWidth()
             )
@@ -131,9 +157,9 @@ private fun AddTeeTimeContent(
 
             // Save Button
             LoadingButton(
-                text = stringResource(TTR.strings.button_create.resourceId),
-                onClick = { onSaveClick(courseName, date.selectedDate) },
-                enabled = courseName.isNotBlank() && date.selectedDate != null && timeSlots.isNotEmpty(),
+                text = stringResource(GR.strings.save.resourceId),
+                onClick = onSaveClick,
+                enabled = canSave,
                 modifier = Modifier.fillMaxWidth(),
                 isLoading = showLoadingProgress
             )
@@ -154,16 +180,21 @@ private fun AddTeeTimeContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun AddTeeTimeContentPreview() {
+private fun EditTeeTimeContentPreview() {
     MyApplicationTheme {
-        AddTeeTimeContent(
+        EditTeeTimeContent(
             showLoadingProgress = false,
-            timeSlots = emptyList(),
+            courseName = "Persimmon Ridge",
+            initialDate = previewTeeTime.date,
+            timeSlots = previewTeeTimeSlotList,
+            hasChanges = false,
+            onCourseNameChange = { },
+            onDateChange = { },
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
             onRemoveTimeSlot = { },
-            onSaveClick = { _, _ -> },
+            onSaveClick = { },
             onBackClick = { }
         )
     }
@@ -171,16 +202,21 @@ private fun AddTeeTimeContentPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun AddTeeTimeContentWithTimesPreview() {
+private fun EditTeeTimeContentWithChangesPreview() {
     MyApplicationTheme {
-        AddTeeTimeContent(
+        EditTeeTimeContent(
             showLoadingProgress = false,
+            courseName = "Persimmon Ridge Golf Club",
+            initialDate = previewTeeTime.date,
             timeSlots = previewTeeTimeSlotList,
+            hasChanges = true,
+            onCourseNameChange = { },
+            onDateChange = { },
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
             onRemoveTimeSlot = { },
-            onSaveClick = { _, _ -> },
+            onSaveClick = { },
             onBackClick = { }
         )
     }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
@@ -1,5 +1,6 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,6 +30,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.feature.teeTimes.common.TeeTimesSection
 import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
+import net.bradball.teetimecaddie.android.ui.common.ContentLoadingIndicator
 import net.bradball.teetimecaddie.android.ui.common.TtcDatePicker
 import net.bradball.teetimecaddie.android.ui.common.TtcTimePickerDialog
 import net.bradball.teetimecaddie.android.ui.common.buttons.LoadingButton
@@ -36,24 +38,16 @@ import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.android.ui.common.rememberTtcDatePickerState
 import net.bradball.teetimecaddie.android.ui.common.selectedDate
 import net.bradball.teetimecaddie.core.models.GR
-import net.bradball.teetimecaddie.core.models.TeeTime
 import net.bradball.teetimecaddie.core.models.TeeTimeSlot
-import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
 import net.bradball.teetimecaddie.features.teetimes.TTR
 
 @Composable
 fun EditTeeTimeScreen(
-    teeTime: TeeTime,
     viewModel: EditTeeTimeViewModel,
     onBack: () -> Unit,
     onTeeTimeSaved: () -> Unit
 ) {
-    // Initialize ViewModel with tee time data
-    LaunchedEffect(teeTime) {
-        viewModel.initialize(teeTime)
-    }
-
     // Handle save success
     LaunchedEffect(viewModel.saveSuccess) {
         if (viewModel.saveSuccess) {
@@ -61,21 +55,48 @@ fun EditTeeTimeScreen(
         }
     }
 
-    EditTeeTimeContent(
-        showLoadingProgress = viewModel.showLoadingProgress,
-        courseName = viewModel.courseName,
-        initialDate = viewModel.selectedDate,
-        timeSlots = viewModel.timeSlots,
-        hasChanges = viewModel.hasChanges,
-        onCourseNameChange = viewModel::updateCourseName,
-        onDateChange = viewModel::updateDate,
-        onAddTimeClick = viewModel::onAddTimeClick,
-        onAddTimeSlot = viewModel::addTimeSlot,
-        onUpdatePlayerCount = viewModel::updatePlayerCount,
-        onRemoveTimeSlot = viewModel::removeTimeSlot,
-        onSaveClick = viewModel::saveTeeTime,
-        onBackClick = onBack
-    )
+    if (viewModel.isLoading) {
+        EditTeeTimeLoadingContent(onBackClick = onBack)
+    } else {
+        EditTeeTimeContent(
+            showLoadingProgress = viewModel.showLoadingProgress,
+            courseName = viewModel.courseName,
+            initialDate = viewModel.selectedDate,
+            timeSlots = viewModel.timeSlots,
+            canSave = viewModel.canSave,
+            onCourseNameChange = viewModel::updateCourseName,
+            onDateChange = viewModel::updateDate,
+            onAddTimeClick = viewModel::onAddTimeClick,
+            onAddTimeSlot = viewModel::addTimeSlot,
+            onUpdatePlayerCount = viewModel::updatePlayerCount,
+            onRemoveTimeSlot = viewModel::removeTimeSlot,
+            onSaveClick = viewModel::saveTeeTime,
+            onBackClick = onBack
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun EditTeeTimeLoadingContent(
+    onBackClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(TTR.strings.edit_tee_time.resourceId)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(TtcIcons.ARROW_BACK.painter, contentDescription = stringResource(GR.strings.back.resourceId))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+            ContentLoadingIndicator()
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -85,7 +106,7 @@ private fun EditTeeTimeContent(
     courseName: String,
     initialDate: LocalDate?,
     timeSlots: List<TeeTimeSlot>,
-    hasChanges: Boolean,
+    canSave: Boolean,
     onCourseNameChange: (String) -> Unit,
     onDateChange: (LocalDate?) -> Unit,
     onAddTimeClick: () -> Unit,
@@ -102,11 +123,6 @@ private fun EditTeeTimeContent(
     LaunchedEffect(date.selectedDate) {
         onDateChange(date.selectedDate)
     }
-
-    val canSave = courseName.isNotBlank() &&
-            date.selectedDate != null &&
-            timeSlots.isNotEmpty() &&
-            hasChanges
 
     Scaffold(
         topBar = {
@@ -180,14 +196,22 @@ private fun EditTeeTimeContent(
 
 @Preview(showBackground = true)
 @Composable
+private fun EditTeeTimeLoadingPreview() {
+    MyApplicationTheme {
+        EditTeeTimeLoadingContent(onBackClick = { })
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
 private fun EditTeeTimeContentPreview() {
     MyApplicationTheme {
         EditTeeTimeContent(
             showLoadingProgress = false,
             courseName = "Persimmon Ridge",
-            initialDate = previewTeeTime.date,
+            initialDate = kotlinx.datetime.LocalDate(2025, 3, 15),
             timeSlots = previewTeeTimeSlotList,
-            hasChanges = false,
+            canSave = false,
             onCourseNameChange = { },
             onDateChange = { },
             onAddTimeClick = { },
@@ -207,9 +231,9 @@ private fun EditTeeTimeContentWithChangesPreview() {
         EditTeeTimeContent(
             showLoadingProgress = false,
             courseName = "Persimmon Ridge Golf Club",
-            initialDate = previewTeeTime.date,
+            initialDate = kotlinx.datetime.LocalDate(2025, 3, 15),
             timeSlots = previewTeeTimeSlotList,
-            hasChanges = true,
+            canSave = true,
             onCourseNameChange = { },
             onDateChange = { },
             onAddTimeClick = { },

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
@@ -32,6 +32,9 @@ class EditTeeTimeViewModel @AssistedInject constructor(
 ): ViewModel() {
 
     // UI state
+    var isLoading: Boolean by mutableStateOf(true)
+        private set
+
     var showLoadingProgress: Boolean by mutableStateOf(false)
         private set
 
@@ -61,17 +64,37 @@ class EditTeeTimeViewModel @AssistedInject constructor(
         }
 
     /**
-     * Initializes the ViewModel with the tee time data.
-     * This should be called by the screen after obtaining the TeeTime.
+     * Indicates whether the Save button should be enabled.
      */
-    fun initialize(teeTime: TeeTime) {
-        if (originalTeeTime != null) return // Already initialized
+    val canSave: Boolean
+        get() = courseName.isNotBlank() &&
+                selectedDate != null &&
+                _timeSlots.isNotEmpty() &&
+                hasChanges
 
-        originalTeeTime = teeTime
-        courseName = teeTime.course
-        selectedDate = teeTime.date
-        _timeSlots.clear()
-        _timeSlots.addAll(teeTime.times)
+    init {
+        loadTeeTime()
+    }
+
+    /**
+     * Loads the tee time from the repository.
+     */
+    private fun loadTeeTime() {
+        viewModelScope.launch {
+            isLoading = true
+            try {
+                val teeTime = teeTimesRepo.getTeeTime(teeTimeId)
+                if (teeTime != null) {
+                    originalTeeTime = teeTime
+                    courseName = teeTime.course
+                    selectedDate = teeTime.date
+                    _timeSlots.clear()
+                    _timeSlots.addAll(teeTime.times)
+                }
+            } finally {
+                isLoading = false
+            }
+        }
     }
 
     /**

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
@@ -1,0 +1,162 @@
+package net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
+import net.bradball.teetimecaddie.core.analytics.EventManager
+import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.features.teetimes.TeeTimesRepository
+
+@AssistedFactory
+interface EditTeeTimeViewModelFactory {
+    fun create(teeTimeId: String): EditTeeTimeViewModel
+}
+
+@HiltViewModel(assistedFactory = EditTeeTimeViewModelFactory::class)
+class EditTeeTimeViewModel @AssistedInject constructor(
+    @Assisted private val teeTimeId: String,
+    private val teeTimesRepo: TeeTimesRepository,
+    private val eventManager: EventManager
+): ViewModel() {
+
+    // UI state
+    var showLoadingProgress: Boolean by mutableStateOf(false)
+        private set
+
+    var saveSuccess: Boolean by mutableStateOf(false)
+        private set
+
+    var courseName: String by mutableStateOf("")
+        private set
+
+    var selectedDate: LocalDate? by mutableStateOf(null)
+        private set
+
+    // The original tee time being edited
+    private var originalTeeTime: TeeTime? = null
+
+    // List of tee time slots
+    private val _timeSlots = mutableStateListOf<TeeTimeSlot>()
+    val timeSlots: List<TeeTimeSlot> get() = _timeSlots.sortedBy { it.time }
+
+    // Indicates whether any changes have been made
+    val hasChanges: Boolean
+        get() {
+            val original = originalTeeTime ?: return false
+            return courseName != original.course ||
+                    selectedDate != original.date ||
+                    _timeSlots.sortedBy { it.time } != original.times.sortedBy { it.time }
+        }
+
+    /**
+     * Initializes the ViewModel with the tee time data.
+     * This should be called by the screen after obtaining the TeeTime.
+     */
+    fun initialize(teeTime: TeeTime) {
+        if (originalTeeTime != null) return // Already initialized
+
+        originalTeeTime = teeTime
+        courseName = teeTime.course
+        selectedDate = teeTime.date
+        _timeSlots.clear()
+        _timeSlots.addAll(teeTime.times)
+    }
+
+    /**
+     * Updates the course name.
+     */
+    fun updateCourseName(name: String) {
+        courseName = name
+    }
+
+    /**
+     * Updates the selected date.
+     */
+    fun updateDate(date: LocalDate?) {
+        selectedDate = date
+    }
+
+    /**
+     * Logs the analytics event when the user clicks the "Add Time" button.
+     */
+    fun onAddTimeClick() {
+        eventManager.logEvent(AnalyticsEvent.AddTimeClick)
+    }
+
+    /**
+     * Adds a new time slot with the default number of players (4).
+     * If the time already exists in the list, it will not be added.
+     *
+     * @param time The time to add.
+     * @return true if the time was added, false if it already existed.
+     */
+    fun addTimeSlot(time: LocalTime): Boolean {
+        if (_timeSlots.any { it.time == time }) {
+            return false
+        }
+        _timeSlots.add(TeeTimeSlot(time = time, numberOfPlayers = 4))
+        eventManager.logEvent(AnalyticsEvent.AddTime)
+        return true
+    }
+
+    /**
+     * Updates the number of players for a specific time slot.
+     *
+     * @param time The time of the slot to update.
+     * @param numberOfPlayers The new number of players (1-4).
+     */
+    fun updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        val index = _timeSlots.indexOfFirst { it.time == time }
+        if (index != -1) {
+            val clampedPlayers = numberOfPlayers.coerceIn(1, 4)
+            _timeSlots[index] = _timeSlots[index].copy(numberOfPlayers = clampedPlayers)
+            eventManager.logEvent(AnalyticsEvent.NumberOfPlayersClick(clampedPlayers))
+        }
+    }
+
+    /**
+     * Removes a time slot from the list and logs the analytics event.
+     *
+     * @param time The time of the slot to remove.
+     */
+    fun removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(AnalyticsEvent.RemoveTimeClick)
+        _timeSlots.removeAll { it.time == time }
+    }
+
+    /**
+     * Saves the edited tee time.
+     */
+    fun saveTeeTime() {
+        val original = originalTeeTime ?: return
+        val date = selectedDate ?: return
+        if (_timeSlots.isEmpty() || courseName.isBlank()) return
+
+        viewModelScope.launch {
+            showLoadingProgress = true
+            try {
+                val updatedTeeTime = original.copy(
+                    course = courseName,
+                    date = date,
+                    times = _timeSlots.toList()
+                )
+                teeTimesRepo.updateTeeTime(updatedTeeTime)
+                saveSuccess = true
+            } finally {
+                showLoadingProgress = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
@@ -14,26 +14,6 @@ import net.bradball.teetimecaddie.android.ui.navigation.TtcNavKey
 import net.bradball.teetimecaddie.core.models.TeeTime
 
 /**
- * Cache for holding TeeTime objects during navigation.
- * Since Navigation3 requires serializable destination keys, we cache the full TeeTime
- * object here and only pass the ID through the navigation destination.
- */
-private object TeeTimeNavigationCache {
-    private val cache = mutableMapOf<String, TeeTime>()
-
-    fun put(teeTime: TeeTime) {
-        val id = teeTime.id ?: return
-        cache[id] = teeTime
-    }
-
-    fun get(id: String): TeeTime? = cache[id]
-
-    fun remove(id: String) {
-        cache.remove(id)
-    }
-}
-
-/**
  * Navigation destination for the Tee Times list screen.
  *
  * This is the main entry point for the Tee Times feature, displaying all upcoming
@@ -87,7 +67,6 @@ fun Navigator.navigateToAddTeeTime() {
  */
 fun Navigator.navigateToEditTeeTime(teeTime: TeeTime) {
     val teeTimeId = requireNotNull(teeTime.id) { "Cannot edit a tee time without an id" }
-    TeeTimeNavigationCache.put(teeTime)
     navigate(EditTeeTimeDestination(teeTimeId))
 }
 
@@ -151,23 +130,13 @@ fun EntryProviderScope<NavKey>.teeTimesEntries(navigator: Navigator) {
     }
 
     entry<EditTeeTimeDestination> { destination ->
-        val teeTime = TeeTimeNavigationCache.get(destination.teeTimeId)
-        if (teeTime != null) {
-            val viewModel = hiltViewModel<EditTeeTimeViewModel, EditTeeTimeViewModelFactory> { factory ->
-                factory.create(destination.teeTimeId)
-            }
-            EditTeeTimeScreen(
-                teeTime = teeTime,
-                viewModel = viewModel,
-                onBack = {
-                    TeeTimeNavigationCache.remove(destination.teeTimeId)
-                    navigator.goBack()
-                },
-                onTeeTimeSaved = {
-                    TeeTimeNavigationCache.remove(destination.teeTimeId)
-                    navigator.goBack()
-                }
-            )
+        val viewModel = hiltViewModel<EditTeeTimeViewModel, EditTeeTimeViewModelFactory> { factory ->
+            factory.create(destination.teeTimeId)
         }
+        EditTeeTimeScreen(
+            viewModel = viewModel,
+            onBack = { navigator.goBack() },
+            onTeeTimeSaved = { navigator.goBack() }
+        )
     }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
@@ -1,12 +1,37 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 import net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime.AddTeeTimeScreen
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeScreen
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeViewModel
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeViewModelFactory
 import net.bradball.teetimecaddie.android.feature.teeTimes.teeTimeList.TeeTimesListScreen
 import net.bradball.teetimecaddie.android.ui.navigation.Navigator
 import net.bradball.teetimecaddie.android.ui.navigation.TtcNavKey
+import net.bradball.teetimecaddie.core.models.TeeTime
+
+/**
+ * Cache for holding TeeTime objects during navigation.
+ * Since Navigation3 requires serializable destination keys, we cache the full TeeTime
+ * object here and only pass the ID through the navigation destination.
+ */
+private object TeeTimeNavigationCache {
+    private val cache = mutableMapOf<String, TeeTime>()
+
+    fun put(teeTime: TeeTime) {
+        val id = teeTime.id ?: return
+        cache[id] = teeTime
+    }
+
+    fun get(id: String): TeeTime? = cache[id]
+
+    fun remove(id: String) {
+        cache.remove(id)
+    }
+}
 
 /**
  * Navigation destination for the Tee Times list screen.
@@ -24,6 +49,14 @@ data object TeeTimesListDestination: TtcNavKey
  */
 @Serializable
 data object AddTeeTimeDestination: TtcNavKey
+
+/**
+ * Navigation destination for the Edit Tee Time screen.
+ *
+ * @property teeTimeId The ID of the tee time to edit.
+ */
+@Serializable
+data class EditTeeTimeDestination(val teeTimeId: String): TtcNavKey
 
 
 /**
@@ -45,6 +78,17 @@ fun Navigator.navigateToTeeTimesList(clearBackStack: Boolean = false) {
  */
 fun Navigator.navigateToAddTeeTime() {
     navigate(AddTeeTimeDestination)
+}
+
+/**
+ * Navigates to the Edit Tee Time screen.
+ *
+ * @param teeTime The tee time to edit.
+ */
+fun Navigator.navigateToEditTeeTime(teeTime: TeeTime) {
+    val teeTimeId = requireNotNull(teeTime.id) { "Cannot edit a tee time without an id" }
+    TeeTimeNavigationCache.put(teeTime)
+    navigate(EditTeeTimeDestination(teeTimeId))
 }
 
 /**
@@ -94,7 +138,8 @@ fun Navigator.navigateToAddTeeTime() {
 fun EntryProviderScope<NavKey>.teeTimesEntries(navigator: Navigator) {
     entry<TeeTimesListDestination> {
         TeeTimesListScreen(
-            onAddTeeTimeClick = { navigator.navigateToAddTeeTime() }
+            onAddTeeTimeClick = { navigator.navigateToAddTeeTime() },
+            onTeeTimeClick = { teeTime -> navigator.navigateToEditTeeTime(teeTime) }
         )
     }
 
@@ -103,5 +148,26 @@ fun EntryProviderScope<NavKey>.teeTimesEntries(navigator: Navigator) {
             onBack = { navigator.goBack() },
             onTeeTimeCreated = { navigator.goBack() }
         )
+    }
+
+    entry<EditTeeTimeDestination> { destination ->
+        val teeTime = TeeTimeNavigationCache.get(destination.teeTimeId)
+        if (teeTime != null) {
+            val viewModel = hiltViewModel<EditTeeTimeViewModel, EditTeeTimeViewModelFactory> { factory ->
+                factory.create(destination.teeTimeId)
+            }
+            EditTeeTimeScreen(
+                teeTime = teeTime,
+                viewModel = viewModel,
+                onBack = {
+                    TeeTimeNavigationCache.remove(destination.teeTimeId)
+                    navigator.goBack()
+                },
+                onTeeTimeSaved = {
+                    TeeTimeNavigationCache.remove(destination.teeTimeId)
+                    navigator.goBack()
+                }
+            )
+        }
     }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
@@ -25,8 +25,13 @@ import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeList
 
 @Composable
-fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
+fun TeeTimeCard(
+    teeTime: TeeTime,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
     Card(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesScreen.kt
@@ -29,20 +29,26 @@ import net.bradball.teetimecaddie.features.teetimes.TTR
 @Composable
 fun TeeTimesListScreen(
     onAddTeeTimeClick: () -> Unit,
+    onTeeTimeClick: (TeeTime) -> Unit,
     viewModel: TeeTimesViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     TeeTimesContent(
         uiState = uiState,
-        onAddTeeTimeClick = onAddTeeTimeClick
+        onAddTeeTimeClick = onAddTeeTimeClick,
+        onTeeTimeClick = { teeTime ->
+            viewModel.onTeeTimeClick()
+            onTeeTimeClick(teeTime)
+        }
     )
 }
 
 @Composable
 fun TeeTimesContent(
     uiState: TeeTimesUiState,
-    onAddTeeTimeClick: () -> Unit = {}
+    onAddTeeTimeClick: () -> Unit = {},
+    onTeeTimeClick: (TeeTime) -> Unit = {}
 ) {
 
     Scaffold(
@@ -66,7 +72,10 @@ fun TeeTimesContent(
                             .fillMaxWidth()
                     )
 
-                    is TeeTimesUiState.Content -> TeeTimesList(uiState.teeTimes)
+                    is TeeTimesUiState.Content -> TeeTimesList(
+                        teeTimes = uiState.teeTimes,
+                        onTeeTimeClick = onTeeTimeClick
+                    )
                 }
             }
         }
@@ -74,11 +83,16 @@ fun TeeTimesContent(
 }
 
 @Composable
-private fun TeeTimesList(teeTimes: List<TeeTime>) {
+private fun TeeTimesList(
+    teeTimes: List<TeeTime>,
+    onTeeTimeClick: (TeeTime) -> Unit
+) {
     LazyColumn(modifier = Modifier.padding(16.dp)) {
         items(teeTimes.size) { index ->
+            val teeTime = teeTimes[index]
             TeeTimeCard(
-                teeTime = teeTimes[index],
+                teeTime = teeTime,
+                onClick = { onTeeTimeClick(teeTime) },
                 modifier = Modifier.padding(bottom = 8.dp)
             )
         }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesViewModel.kt
@@ -1,18 +1,15 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.teeTimeList
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
+import net.bradball.teetimecaddie.core.analytics.EventManager
 import net.bradball.teetimecaddie.core.models.TeeTime
 import net.bradball.teetimecaddie.features.auth.AuthRepository
 import net.bradball.teetimecaddie.features.teetimes.TeeTimesRepository
@@ -28,7 +25,8 @@ sealed interface TeeTimesUiState {
 @HiltViewModel
 class TeeTimesViewModel @Inject constructor(
     private val teeTimesRepo: TeeTimesRepository,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val eventManager: EventManager
 ): ViewModel() {
 
     val uiState: StateFlow<TeeTimesUiState> = teeTimesRepo.getTeeTimes(authRepository.currentUser.id)
@@ -44,4 +42,11 @@ class TeeTimesViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(1_000),
             initialValue = TeeTimesUiState.Loading
         )
+
+    /**
+     * Logs the analytics event when the user clicks on a tee time item.
+     */
+    fun onTeeTimeClick() {
+        eventManager.logEvent(AnalyticsEvent.TeeTimeListItemClick)
+    }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/DatePicker.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/DatePicker.kt
@@ -109,7 +109,10 @@ fun TtcDatePicker(
 
 @OptIn(ExperimentalTime::class)
 @Composable
-fun rememberTtcDatePickerState(initialDisplayMode: DisplayMode = DisplayMode.Input): DatePickerState {
+fun rememberTtcDatePickerState(
+    initialDate: LocalDate? = null,
+    initialDisplayMode: DisplayMode = DisplayMode.Input
+): DatePickerState {
 
     val today: LocalDate = Clock.System.todayIn(TimeZone.UTC)
     val selectableYears = IntRange(today.year, today.year + 5)
@@ -124,7 +127,14 @@ fun rememberTtcDatePickerState(initialDisplayMode: DisplayMode = DisplayMode.Inp
         }
     }
 
-    return rememberDatePickerState(initialDisplayMode = initialDisplayMode, yearRange = selectableYears,  selectableDates = selectableTeeTimeDates)
+    val initialDateMillis = initialDate?.toEpochMilliseconds(TimeZone.UTC)
+
+    return rememberDatePickerState(
+        initialSelectedDateMillis = initialDateMillis,
+        initialDisplayMode = initialDisplayMode,
+        yearRange = selectableYears,
+        selectableDates = selectableTeeTimeDates
+    )
 }
 
 

--- a/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
@@ -81,6 +81,10 @@ sealed class AnalyticsEvent(val name: String, internal val type: EventType) {
     data class NumberOfPlayersClick(val numberOfPlayers: Int): AnalyticsEvent("number_of_players_click", EventType.CLICK)
     @Serializable
     object RemoveTimeClick: AnalyticsEvent("remove_time_click", EventType.CLICK)
+    @Serializable
+    object TeeTimeListItemClick: AnalyticsEvent("tee_time_list_item_click", EventType.CLICK)
+    @Serializable
+    data class EditTeeTime(val times: Int, val players: Int): AnalyticsEvent("tee_time_edit", EventType.OPERATION)
 
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsScreen.kt
@@ -68,4 +68,7 @@ sealed class AnalyticsScreen(val name: String, val viewName: String, val paramet
 
     /** The screen for adding a new tee time */
     class AddTeeTime(viewName: String): AnalyticsScreen(name = "AddTeeTime", viewName)
+
+    /** The screen for editing an existing tee time */
+    class EditTeeTime(viewName: String): AnalyticsScreen(name = "EditTeeTime", viewName)
 }

--- a/core/models/src/commonMain/moko-resources/base/strings.xml
+++ b/core/models/src/commonMain/moko-resources/base/strings.xml
@@ -7,4 +7,5 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
+    <string name="save">Save</string>
 </resources>

--- a/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
+++ b/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
@@ -48,6 +48,21 @@ class TeeTimeStorage {
         teeTimesCollection.document(id).set(document)
     }
 
+    /**
+     * Get a single Tee Time by ID.
+     *
+     * @param teeTimeId The ID of the tee time to retrieve.
+     * @return The [TeeTimeDocument] if found, null otherwise.
+     */
+    suspend fun getTeeTime(teeTimeId: String): TeeTimeDocument? {
+        val snapshot = teeTimesCollection.document(teeTimeId).get()
+        return if (snapshot.exists) {
+            snapshot.data<TeeTimeDocument>().apply { id = snapshot.id }
+        } else {
+            null
+        }
+    }
+
     @OptIn(ExperimentalTime::class)
     suspend fun getTeeTimes(playerId: String): List<TeeTimeDocument> {
         val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
+++ b/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
@@ -37,6 +37,17 @@ class TeeTimeStorage {
      */
     suspend fun addTeeTime(document: TeeTimeDocument): String = teeTimesCollection.add(document).id
 
+    /**
+     * Update an existing Tee Time in the database.
+     *
+     * @param document A [TeeTimeDocument] with the updated information. Must have a non-null id.
+     * @throws IllegalArgumentException if the document id is null.
+     */
+    suspend fun updateTeeTime(document: TeeTimeDocument) {
+        val id = requireNotNull(document.id) { "Cannot update a tee time without an id" }
+        teeTimesCollection.document(id).set(document)
+    }
+
     @OptIn(ExperimentalTime::class)
     suspend fun getTeeTimes(playerId: String): List<TeeTimeDocument> {
         val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
@@ -64,6 +64,17 @@ class TeeTimesRepository(
         }
 
     /**
+     * Gets a single tee time by ID.
+     *
+     * @param teeTimeId The ID of the tee time to retrieve.
+     * @return The TeeTime if found, null otherwise.
+     */
+    @Throws(CancellationException::class)
+    suspend fun getTeeTime(teeTimeId: String): TeeTime? {
+        return teeTimeStorage.getTeeTime(teeTimeId)?.toModel()
+    }
+
+    /**
      * Updates an existing tee time.
      *
      * @param teeTime The tee time to update. Must have a non-null id.

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
@@ -62,4 +62,31 @@ class TeeTimesRepository(
         .mapLatest { list ->
             list.map { it.toModel() }
         }
+
+    /**
+     * Updates an existing tee time.
+     *
+     * @param teeTime The tee time to update. Must have a non-null id.
+     * @return The updated TeeTime.
+     * @throws IllegalArgumentException if the tee time id is null.
+     */
+    @Throws(CancellationException::class)
+    suspend fun updateTeeTime(teeTime: TeeTime): TeeTime {
+        requireNotNull(teeTime.id) { "Cannot update a tee time without an id" }
+
+        val sortedTimes = teeTime.times.sortedBy { it.time }
+        val doc = teeTime.toDocument().apply {
+            id = teeTime.id
+        }
+
+        teeTimeStorage.updateTeeTime(doc)
+
+        val totalPlayers = sortedTimes.fold(0) { total, slot ->
+            total + slot.numberOfPlayers
+        }
+
+        eventManager.logEvent(AnalyticsEvent.EditTeeTime(sortedTimes.count(), totalPlayers))
+
+        return teeTime.copy(times = sortedTimes)
+    }
 }

--- a/features/teetimes/src/commonMain/moko-resources/base/strings.xml
+++ b/features/teetimes/src/commonMain/moko-resources/base/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="tee_times_title">Tee Times</string>
     <string name="add_tee_time">Add Tee Time</string>
+    <string name="edit_tee_time">Edit Tee Time</string>
     <string name="empty_tee_times_title">Tee Sheet is Wide Open</string>
     <string name="empty_tee_times_message">You don\'t have an scheduled tee times.</string>
 

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
@@ -10,14 +10,16 @@ import TeeTimeCaddieKit
 enum TeeTimesDestinations: @MainActor TtcNavKey {
     case teeTimesList
     case addTeeTime
+    case editTeeTime(TeeTime)
 
     @ViewBuilder
     func destinationView(_ navigator: Navigator) -> some View {
-       
+
         switch self {
         case .teeTimesList:
             TeeTimesListScreen(
-                onAddTeeTimeClick: { navigator.navigateToAddTeeTime() }
+                onAddTeeTimeClick: { navigator.navigateToAddTeeTime() },
+                onTeeTimeClick: { teeTime in navigator.navigateToEditTeeTime(teeTime) }
             )
             .navigationTitle(TTR.strings().tee_times_title.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
@@ -28,6 +30,15 @@ enum TeeTimesDestinations: @MainActor TtcNavKey {
                 onTeeTimeCreated: { navigator.pop() }
             )
             .navigationTitle(TTR.strings().add_tee_time.desc().localized())
+            .navigationBarTitleDisplayMode(.inline)
+
+        case .editTeeTime(let teeTime):
+            EditTeeTimeScreen(
+                teeTime: teeTime,
+                onBack: { navigator.pop() },
+                onTeeTimeSaved: { navigator.pop() }
+            )
+            .navigationTitle(TTR.strings().edit_tee_time.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
         }
     }
@@ -45,5 +56,9 @@ extension Navigator {
 
     func navigateToAddTeeTime() {
         self.navigate(to: TeeTimesDestinations.addTeeTime)
+    }
+
+    func navigateToEditTeeTime(_ teeTime: TeeTime) {
+        self.navigate(to: TeeTimesDestinations.editTeeTime(teeTime))
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
@@ -10,7 +10,7 @@ import TeeTimeCaddieKit
 enum TeeTimesDestinations: @MainActor TtcNavKey {
     case teeTimesList
     case addTeeTime
-    case editTeeTime(TeeTime)
+    case editTeeTime(String)
 
     @ViewBuilder
     func destinationView(_ navigator: Navigator) -> some View {
@@ -32,9 +32,9 @@ enum TeeTimesDestinations: @MainActor TtcNavKey {
             .navigationTitle(TTR.strings().add_tee_time.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
 
-        case .editTeeTime(let teeTime):
+        case .editTeeTime(let teeTimeId):
             EditTeeTimeScreen(
-                teeTime: teeTime,
+                teeTimeId: teeTimeId,
                 onBack: { navigator.pop() },
                 onTeeTimeSaved: { navigator.pop() }
             )
@@ -59,6 +59,7 @@ extension Navigator {
     }
 
     func navigateToEditTeeTime(_ teeTime: TeeTime) {
-        self.navigate(to: TeeTimesDestinations.editTeeTime(teeTime))
+        guard let teeTimeId = teeTime.id else { return }
+        self.navigate(to: TeeTimesDestinations.editTeeTime(teeTimeId))
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TeeTimeFormComponents.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TeeTimeFormComponents.swift
@@ -1,0 +1,161 @@
+//
+//  TeeTimeFormComponents.swift
+//  TeeTimeCaddie
+//
+//  Created by Claude on 2/6/26.
+//
+
+import SwiftUI
+import TeeTimeCaddieKit
+
+// MARK: - Tee Times Section
+
+/// A section displaying the list of tee time slots with an "Add Time" button.
+struct TeeTimesSection: View {
+    let timeSlots: [TeeTimeSlot]
+    let onAddTimeClick: () -> Void
+    let onUpdatePlayerCount: (LocalTime, Int) -> Void
+    let onRemoveTimeSlot: (LocalTime) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Section Header
+            Text(TTR.strings().tee_times_section_header.desc().localized())
+                .font(.headline)
+
+            // List of time slots
+            ForEach(timeSlots, id: \.time) { slot in
+                TimeSlotRow(
+                    slot: slot,
+                    onUpdatePlayerCount: { players in
+                        onUpdatePlayerCount(slot.time, players)
+                    },
+                    onRemove: {
+                        onRemoveTimeSlot(slot.time)
+                    }
+                )
+                Divider()
+            }
+
+            // Add Time Button
+            Button(action: onAddTimeClick) {
+                HStack {
+                    Image(systemName: "plus")
+                    Text(TTR.strings().add_time_button.desc().localized())
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}
+
+// MARK: - Time Slot Row
+
+/// A row displaying a single time slot with time, player count slider, and remove button.
+struct TimeSlotRow: View {
+    let slot: TeeTimeSlot
+    let onUpdatePlayerCount: (Int) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Time display with trash icon
+            HStack {
+                Text(slot.time.formattedTime)
+                    .font(.headline)
+
+                Spacer()
+
+                Button(action: onRemove) {
+                    Image("icons/trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(GR.strings().delete.desc().localized())
+            }
+
+            // Player count slider
+            HStack {
+                Text(TTR.strings().players_label.desc().localized())
+                    .font(.body)
+
+                Slider(
+                    value: Binding(
+                        get: { Double(slot.numberOfPlayers) },
+                        set: { onUpdatePlayerCount(Int($0)) }
+                    ),
+                    in: 1...4,
+                    step: 1
+                )
+
+                Text("\(slot.numberOfPlayers)")
+                    .font(.headline)
+                    .frame(width: 30)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Time Picker Sheet
+
+/// A sheet for picking a time.
+struct TimePickerSheet: View {
+    @Binding var selectedTime: Date
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            DatePicker(
+                "",
+                selection: $selectedTime,
+                displayedComponents: .hourAndMinute
+            )
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .navigationTitle(TTR.strings().field_Label_Time.desc().localized())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(GR.strings().cancel.desc().localized()) {
+                        onCancel()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(GR.strings().ok.desc().localized()) {
+                        onConfirm()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Tee Times Section - Empty") {
+    TeeTimeCaddieTheme {
+        TeeTimesSection(
+            timeSlots: [],
+            onAddTimeClick: {},
+            onUpdatePlayerCount: { _, _ in },
+            onRemoveTimeSlot: { _ in }
+        )
+        .padding()
+    }
+}
+
+#Preview("Tee Times Section - With Times") {
+    TeeTimeCaddieTheme {
+        TeeTimesSection(
+            timeSlots: TeeTimeKt.previewTeeTimeSlotList,
+            onAddTimeClick: {},
+            onUpdatePlayerCount: { _, _ in },
+            onRemoveTimeSlot: { _ in }
+        )
+        .padding()
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
@@ -9,12 +9,12 @@ import SwiftUI
 import TeeTimeCaddieKit
 
 struct EditTeeTimeScreen: View {
-    let teeTime: TeeTime
+    let teeTimeId: String
     let onBack: () -> Void
     let onTeeTimeSaved: () -> Void
 
     @State
-    private var viewModel = EditTeeTimeViewModel()
+    private var viewModel: EditTeeTimeViewModel
 
     @State
     private var showTimePicker: Bool = false
@@ -27,31 +27,42 @@ struct EditTeeTimeScreen: View {
         of: Date()
     ) ?? Date()
 
+    init(teeTimeId: String, onBack: @escaping () -> Void, onTeeTimeSaved: @escaping () -> Void) {
+        self.teeTimeId = teeTimeId
+        self.onBack = onBack
+        self.onTeeTimeSaved = onTeeTimeSaved
+        self._viewModel = State(initialValue: EditTeeTimeViewModel(teeTimeId: teeTimeId))
+    }
+
     var body: some View {
         Screen(AnalyticsScreen.EditTeeTime(viewName: self.viewName)) {
-            EditTeeTimeContent(
-                courseName: Binding(
-                    get: { viewModel.courseName },
-                    set: { viewModel.courseName = $0 }
-                ),
-                selectedDate: Binding(
-                    get: { viewModel.selectedDate },
-                    set: { viewModel.selectedDate = $0 }
-                ),
-                timeSlots: viewModel.timeSlots,
-                isLoading: viewModel.showLoadingProgress,
-                canSave: canSave,
-                onAddTimeClick: {
-                    viewModel.onAddTimeClick()
-                    showTimePicker = true
-                },
-                onUpdatePlayerCount: viewModel.updatePlayerCount,
-                onRemoveTimeSlot: viewModel.removeTimeSlot,
-                onSave: viewModel.saveTeeTime
-            )
+            if viewModel.isLoading {
+                ContentLoadingIndicator()
+            } else {
+                EditTeeTimeContent(
+                    courseName: Binding(
+                        get: { viewModel.courseName },
+                        set: { viewModel.courseName = $0 }
+                    ),
+                    selectedDate: Binding(
+                        get: { viewModel.selectedDate },
+                        set: { viewModel.selectedDate = $0 }
+                    ),
+                    timeSlots: viewModel.timeSlots,
+                    isLoading: viewModel.showLoadingProgress,
+                    canSave: viewModel.canSave,
+                    onAddTimeClick: {
+                        viewModel.onAddTimeClick()
+                        showTimePicker = true
+                    },
+                    onUpdatePlayerCount: viewModel.updatePlayerCount,
+                    onRemoveTimeSlot: viewModel.removeTimeSlot,
+                    onSave: viewModel.saveTeeTime
+                )
+            }
         }
-        .onAppear {
-            viewModel.initialize(teeTime: teeTime)
+        .task {
+            await viewModel.loadTeeTime()
         }
         .sheet(isPresented: $showTimePicker) {
             TimePickerSheet(
@@ -68,12 +79,6 @@ struct EditTeeTimeScreen: View {
                 onTeeTimeSaved()
             }
         }
-    }
-
-    private var canSave: Bool {
-        !viewModel.courseName.isEmpty &&
-        !viewModel.timeSlots.isEmpty &&
-        viewModel.hasChanges
     }
 }
 

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
@@ -1,25 +1,20 @@
 //
-//  AddTeeTimeScreen.swift
+//  EditTeeTimeScreen.swift
 //  TeeTimeCaddie
 //
-//  Created by Bradley Ball on 1/10/26.
+//  Created by Claude on 2/6/26.
 //
 
 import SwiftUI
 import TeeTimeCaddieKit
 
-struct AddTeeTimeScreen: View {
+struct EditTeeTimeScreen: View {
+    let teeTime: TeeTime
     let onBack: () -> Void
-    let onTeeTimeCreated: () -> Void
+    let onTeeTimeSaved: () -> Void
 
     @State
-    private var viewModel = AddTeeTimeViewModel()
-
-    @State
-    var courseName: String = ""
-
-    @State
-    var selectedDate: Date = Date()
+    private var viewModel = EditTeeTimeViewModel()
 
     @State
     private var showTimePicker: Bool = false
@@ -33,25 +28,30 @@ struct AddTeeTimeScreen: View {
     ) ?? Date()
 
     var body: some View {
-        Screen(AnalyticsScreen.AddTeeTime(viewName: self.viewName)) {
-            AddTeeTimeContent(
-                courseName: $courseName,
-                selectedDate: $selectedDate,
+        Screen(AnalyticsScreen.EditTeeTime(viewName: self.viewName)) {
+            EditTeeTimeContent(
+                courseName: Binding(
+                    get: { viewModel.courseName },
+                    set: { viewModel.courseName = $0 }
+                ),
+                selectedDate: Binding(
+                    get: { viewModel.selectedDate },
+                    set: { viewModel.selectedDate = $0 }
+                ),
                 timeSlots: viewModel.timeSlots,
                 isLoading: viewModel.showLoadingProgress,
+                canSave: canSave,
                 onAddTimeClick: {
                     viewModel.onAddTimeClick()
                     showTimePicker = true
                 },
                 onUpdatePlayerCount: viewModel.updatePlayerCount,
                 onRemoveTimeSlot: viewModel.removeTimeSlot,
-                onSave: {
-                    viewModel.saveTeeTime(
-                        courseName: courseName,
-                        selectedDate: selectedDate
-                    )
-                }
+                onSave: viewModel.saveTeeTime
             )
+        }
+        .onAppear {
+            viewModel.initialize(teeTime: teeTime)
         }
         .sheet(isPresented: $showTimePicker) {
             TimePickerSheet(
@@ -65,27 +65,30 @@ struct AddTeeTimeScreen: View {
         }
         .onChange(of: viewModel.saveSuccess) { _, newValue in
             if newValue {
-                onTeeTimeCreated()
+                onTeeTimeSaved()
             }
         }
+    }
+
+    private var canSave: Bool {
+        !viewModel.courseName.isEmpty &&
+        !viewModel.timeSlots.isEmpty &&
+        viewModel.hasChanges
     }
 }
 
 // MARK: - Content View
 
-fileprivate struct AddTeeTimeContent: View {
+fileprivate struct EditTeeTimeContent: View {
     @Binding var courseName: String
     @Binding var selectedDate: Date
     let timeSlots: [TeeTimeSlot]
     let isLoading: Bool
+    let canSave: Bool
     let onAddTimeClick: () -> Void
     let onUpdatePlayerCount: (LocalTime, Int) -> Void
     let onRemoveTimeSlot: (LocalTime) -> Void
     let onSave: () -> Void
-
-    private var canSave: Bool {
-        !courseName.isEmpty && !timeSlots.isEmpty
-    }
 
     var body: some View {
         ScrollView {
@@ -116,7 +119,7 @@ fileprivate struct AddTeeTimeContent: View {
                     .frame(height: 32)
 
                 // Save Button
-                LoadingButton(TTR.strings().button_create.desc().localized(), isLoading: isLoading, action: onSave)
+                LoadingButton(GR.strings().save.desc().localized(), isLoading: isLoading, action: onSave)
                     .buttonStyle(.Filled)
                     .disabled(!canSave)
             }
@@ -127,39 +130,27 @@ fileprivate struct AddTeeTimeContent: View {
 
 // MARK: - Previews
 
-#Preview("Empty") {
+#Preview("Edit Tee Time") {
     TeeTimeCaddieTheme {
         NavigationStack {
-            AddTeeTimeScreen(
-                onBack: {},
-                onTeeTimeCreated: {}
-            )
-            .navigationTitle(TTR.strings().add_tee_time.desc().localized())
-            .navigationBarTitleDisplayMode(.inline)
-        }
-    }
-}
-
-#Preview("With Times") {
-    TeeTimeCaddieTheme {
-        NavigationStack {
-            AddTeeTimeContentPreviewWrapper()
-                .navigationTitle(TTR.strings().add_tee_time.desc().localized())
+            EditTeeTimeContentPreviewWrapper()
+                .navigationTitle(TTR.strings().edit_tee_time.desc().localized())
                 .navigationBarTitleDisplayMode(.inline)
         }
     }
 }
 
-fileprivate struct AddTeeTimeContentPreviewWrapper: View {
+fileprivate struct EditTeeTimeContentPreviewWrapper: View {
     @State var courseName: String = "Persimmon Ridge"
     @State var selectedDate: Date = Date()
 
     var body: some View {
-        AddTeeTimeContent(
+        EditTeeTimeContent(
             courseName: $courseName,
             selectedDate: $selectedDate,
             timeSlots: TeeTimeKt.previewTeeTimeSlotList,
             isLoading: false,
+            canSave: true,
             onAddTimeClick: {},
             onUpdatePlayerCount: { _, _ in },
             onRemoveTimeSlot: { _ in },

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
@@ -1,0 +1,157 @@
+//
+//  EditTeeTimeViewModel.swift
+//  TeeTimeCaddie
+//
+//  Created by Claude on 2/6/26.
+//
+
+import Foundation
+import TeeTimeCaddieKit
+import Factory
+
+@Observable
+class EditTeeTimeViewModel {
+    private let teeTimesRepo: TeeTimesRepository
+    private let eventManager: EventManager
+
+    private(set) var showLoadingProgress: Bool = false
+    private(set) var saveSuccess: Bool = false
+
+    var courseName: String = ""
+    var selectedDate: Date = Date()
+
+    /// List of tee time slots, sorted by time
+    private(set) var timeSlots: [TeeTimeSlot] = []
+
+    /// The original tee time being edited
+    private var originalTeeTime: TeeTime?
+
+    /// Indicates whether any changes have been made
+    var hasChanges: Bool {
+        guard let original = originalTeeTime else { return false }
+        let originalDate = original.date.toDate()
+        let sortedOriginalTimes = original.times.sorted { $0.time.compareTo(other: $1.time) < 0 }
+        let sortedCurrentTimes = timeSlots.sorted { $0.time.compareTo(other: $1.time) < 0 }
+
+        return courseName != original.course ||
+               !Calendar.current.isDate(selectedDate, inSameDayAs: originalDate) ||
+               !areTimeSlotsEqual(sortedCurrentTimes, sortedOriginalTimes)
+    }
+
+    init(
+        teeTimesRepo: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
+        eventManager: EventManager = AppModule.shared.eventManager()
+    ) {
+        self.teeTimesRepo = teeTimesRepo
+        self.eventManager = eventManager
+    }
+
+    /// Initializes the ViewModel with the tee time data.
+    func initialize(teeTime: TeeTime) {
+        guard originalTeeTime == nil else { return } // Already initialized
+
+        originalTeeTime = teeTime
+        courseName = teeTime.course
+        selectedDate = teeTime.date.toDate()
+        timeSlots = Array(teeTime.times)
+    }
+
+    /// Logs the analytics event when the user clicks the "Add Time" button.
+    func onAddTimeClick() {
+        eventManager.logEvent(event: AnalyticsEvent.AddTimeClick())
+    }
+
+    /// Adds a new time slot with the default number of players (4).
+    /// - Parameter time: The time to add (as a Date).
+    /// - Returns: true if the time was added, false if it already existed.
+    @discardableResult
+    func addTimeSlot(time: Date) -> Bool {
+        let localTime = time.toLocalTime()
+
+        // Check if time already exists
+        if timeSlots.contains(where: { $0.time == localTime }) {
+            return false
+        }
+
+        let newSlot = TeeTimeSlot(time: localTime, numberOfPlayers: 4)
+        timeSlots.append(newSlot)
+        timeSlots.sort { $0.time.compareTo(other: $1.time) < 0 }
+        eventManager.logEvent(event: AnalyticsEvent.AddTime())
+        return true
+    }
+
+    /// Updates the number of players for a specific time slot.
+    /// - Parameters:
+    ///   - time: The LocalTime of the slot to update.
+    ///   - numberOfPlayers: The new number of players (1-4).
+    func updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        guard let index = timeSlots.firstIndex(where: { $0.time == time }) else { return }
+        let clampedPlayers = min(max(numberOfPlayers, 1), 4)
+        timeSlots[index] = TeeTimeSlot(time: time, numberOfPlayers: Int32(clampedPlayers))
+        eventManager.logEvent(event: AnalyticsEvent.NumberOfPlayersClick(numberOfPlayers: Int32(clampedPlayers)))
+    }
+
+    /// Removes a time slot from the list and logs the analytics event.
+    /// - Parameter time: The LocalTime of the slot to remove.
+    func removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(event: AnalyticsEvent.RemoveTimeClick())
+        timeSlots.removeAll { $0.time == time }
+    }
+
+    /// Saves the edited tee time.
+    func saveTeeTime() {
+        guard let original = originalTeeTime,
+              !courseName.isEmpty,
+              !timeSlots.isEmpty else {
+            return
+        }
+
+        Task {
+            showLoadingProgress = true
+            defer { showLoadingProgress = false }
+
+            do {
+                let localDate = selectedDate.toLocalDate()
+
+                let updatedTeeTime = TeeTime(
+                    id: original.id,
+                    createdBy: original.createdBy,
+                    course: courseName,
+                    date: localDate,
+                    times: timeSlots
+                )
+
+                _ = try await teeTimesRepo.updateTeeTime(teeTime: updatedTeeTime)
+                saveSuccess = true
+            } catch {
+                print("Error updating tee time: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func areTimeSlotsEqual(_ lhs: [TeeTimeSlot], _ rhs: [TeeTimeSlot]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        for (left, right) in zip(lhs, rhs) {
+            if left.time != right.time || left.numberOfPlayers != right.numberOfPlayers {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+// MARK: - LocalDate Extension
+
+private extension LocalDate {
+    func toDate() -> Date {
+        let calendar = Calendar.current
+        let components = DateComponents(
+            year: Int(self.year),
+            month: Int(self.month.number),
+            day: Int(self.day)
+        )
+        return calendar.date(from: components) ?? Date()
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
@@ -13,7 +13,9 @@ import Factory
 class EditTeeTimeViewModel {
     private let teeTimesRepo: TeeTimesRepository
     private let eventManager: EventManager
+    private let teeTimeId: String
 
+    private(set) var isLoading: Bool = true
     private(set) var showLoadingProgress: Bool = false
     private(set) var saveSuccess: Bool = false
 
@@ -38,22 +40,36 @@ class EditTeeTimeViewModel {
                !areTimeSlotsEqual(sortedCurrentTimes, sortedOriginalTimes)
     }
 
+    /// Indicates whether the Save button should be enabled
+    var canSave: Bool {
+        !courseName.isEmpty && !timeSlots.isEmpty && hasChanges
+    }
+
     init(
+        teeTimeId: String,
         teeTimesRepo: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
         eventManager: EventManager = AppModule.shared.eventManager()
     ) {
+        self.teeTimeId = teeTimeId
         self.teeTimesRepo = teeTimesRepo
         self.eventManager = eventManager
     }
 
-    /// Initializes the ViewModel with the tee time data.
-    func initialize(teeTime: TeeTime) {
-        guard originalTeeTime == nil else { return } // Already initialized
+    /// Loads the tee time from the repository.
+    func loadTeeTime() async {
+        isLoading = true
+        defer { isLoading = false }
 
-        originalTeeTime = teeTime
-        courseName = teeTime.course
-        selectedDate = teeTime.date.toDate()
-        timeSlots = Array(teeTime.times)
+        do {
+            if let teeTime = try await teeTimesRepo.getTeeTime(teeTimeId: teeTimeId) {
+                originalTeeTime = teeTime
+                courseName = teeTime.course
+                selectedDate = teeTime.date.toDate()
+                timeSlots = Array(teeTime.times)
+            }
+        } catch {
+            print("Error loading tee time: \(error)")
+        }
     }
 
     /// Logs the analytics event when the user clicks the "Add Time" button.

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreen.swift
@@ -11,13 +11,17 @@ import TeeTimeCaddieKit
 
 struct TeeTimesListScreen: View {
     let onAddTeeTimeClick: () -> Void
+    let onTeeTimeClick: (TeeTime) -> Void
 
     @State
     private var viewModel = TeeTimesListScreenViewModel()
 
     var body: some View {
         Screen(AnalyticsScreen.TeeTimeList(viewName: self.viewName)) {
-            TeeTimesListContent(uiState: viewModel.uiState)
+            TeeTimesListContent(uiState: viewModel.uiState, onTeeTimeClick: { teeTime in
+                viewModel.onTeeTimeClick()
+                onTeeTimeClick(teeTime)
+            })
         }
         .task { await viewModel.loadTeetimes() }
         .toolbar {
@@ -31,11 +35,13 @@ struct TeeTimesListScreen: View {
 
 fileprivate struct TeeTimesListContent: View {
     private var uiState: UiState<[TeeTime]>
-    
-    init(uiState: UiState<[TeeTime]>) {
+    private var onTeeTimeClick: (TeeTime) -> Void
+
+    init(uiState: UiState<[TeeTime]>, onTeeTimeClick: @escaping (TeeTime) -> Void) {
         self.uiState = uiState
+        self.onTeeTimeClick = onTeeTimeClick
     }
-        
+
     var body: some View {
         switch uiState {
             case .Loading:
@@ -48,25 +54,25 @@ fileprivate struct TeeTimesListContent: View {
                     icon: .teeEmpty)
 
             case .Content(let list):
-                TeeTimesList(list, onItemTapped: {teeTime in })
+                TeeTimesList(list, onItemTapped: onTeeTimeClick)
         }
     }
 }
 
 #Preview("Content") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Content(TeeTimeKt.previewTeeTimeList))
+        TeeTimesListContent(uiState: .Content(TeeTimeKt.previewTeeTimeList), onTeeTimeClick: { _ in })
     }
 }
 
 #Preview("Loading") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Loading)
+        TeeTimesListContent(uiState: .Loading, onTeeTimeClick: { _ in })
     }
 }
 
 #Preview("Empty") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Empty)
+        TeeTimesListContent(uiState: .Empty, onTeeTimeClick: { _ in })
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreenViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreenViewModel.swift
@@ -6,29 +6,37 @@ class TeeTimesListScreenViewModel {
 
     private let teeTimesRepo: TeeTimesRepository
     private let authRepo: AuthRepository
+    private let eventManager: EventManager
 
     init(teeTimesRepository: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
-         authRepository: AuthRepository = AuthModule.shared.authRepository()) {
+         authRepository: AuthRepository = AuthModule.shared.authRepository(),
+         eventManager: EventManager = AppModule.shared.eventManager()) {
         self.teeTimesRepo = teeTimesRepository
         self.authRepo = authRepository
+        self.eventManager = eventManager
     }
 
     private(set) var uiState: UiState<[TeeTime]> = .Loading
-    
+
     var addButtonEnabled: Bool {
         uiState != .Loading
     }
-    
+
     func loadTeetimes() async {
-        
+
         if !uiState.hasContent {
             uiState = .Loading
         }
-        
+
         for await teeTimesList in teeTimesRepo.getTeeTimes(player: authRepo.currentUser.id) {
             print("Got TeeTimes \(teeTimesList.count)")
             uiState = (teeTimesList.isEmpty) ? .Empty : .Content(teeTimesList)
         }
     }
-    
+
+    /// Logs the analytics event when the user clicks on a tee time item.
+    func onTeeTimeClick() {
+        eventManager.logEvent(event: AnalyticsEvent.TeeTimeListItemClick())
+    }
+
 }


### PR DESCRIPTION
## Summary
- Implement Edit Tee Time screen for both Android and iOS platforms
- Add ability to edit existing tee times (course name, date, time slots)
- Extract common UI components from Add Tee Time for reuse
- Add analytics events for tee time list item click and edit operations

## Changes

### KMP Shared Code
- Add `updateTeeTime` method to `TeeTimeStorage` and `TeeTimesRepository`
- Add analytics events: `TeeTimeListItemClick` (CLICK) and `EditTeeTime` (OPERATION)
- Add `AnalyticsScreen.EditTeeTime` for screen tracking
- Add string resources: `edit_tee_time` (teetimes), `save` (core:models)

### Android
- Extract `TeeTimesSection` and `TimeSlotRow` to common components
- Create `EditTeeTimeViewModel` with AssistedInject for teeTimeId parameter
- Create `EditTeeTimeScreen` using shared form components
- Update navigation with `EditTeeTimeDestination` and cache for TeeTime objects
- Update `TeeTimeCard` to handle click events
- Update `rememberTtcDatePickerState` to accept optional initial date

### iOS
- Extract `TeeTimesSection`, `TimeSlotRow`, and `TimePickerSheet` to common
- Create `EditTeeTimeViewModel` (@Observable)
- Create `EditTeeTimeScreen` using shared form components
- Update navigation with `editTeeTime` case
- Update list screen and ViewModel for click handling and analytics

## Test plan
- [x] Android app builds successfully
- [x] iOS app builds successfully
- [ ] Verify clicking a tee time in the list navigates to Edit screen
- [ ] Verify Edit screen pre-populates with existing tee time data
- [ ] Verify Save button is disabled until changes are made
- [ ] Verify saving updates the tee time in Firestore
- [ ] Verify analytics events are logged correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)