### PR TITLE
Edit Test 3

### DIFF
--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TeeTimesSection.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TeeTimesSection.kt
@@ -1,0 +1,73 @@
+package net.bradball.teetimecaddie.android.feature.teeTimes.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import kotlinx.datetime.LocalTime
+import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.features.teetimes.TTR
+
+/**
+ * A section displaying a list of tee time slots with an "Add Time" button.
+ *
+ * This composable is shared between the Add and Edit Tee Time screens.
+ *
+ * @param timeSlots The list of time slots to display.
+ * @param onAddTimeClick Callback when the "Add Time" button is clicked.
+ * @param onUpdatePlayerCount Callback when a player count slider changes.
+ * @param onRemoveTimeSlot Callback when a time slot is removed.
+ */
+@Composable
+fun TeeTimesSection(
+    timeSlots: List<TeeTimeSlot>,
+    onAddTimeClick: () -> Unit,
+    onUpdatePlayerCount: (LocalTime, Int) -> Unit,
+    onRemoveTimeSlot: (LocalTime) -> Unit
+) {
+    Column {
+        // Section Header
+        Text(
+            text = stringResource(TTR.strings.tee_times_section_header.resourceId),
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // List of time slots
+        if (timeSlots.isNotEmpty()) {
+            timeSlots.forEach { slot ->
+                TimeSlotRow(
+                    slot = slot,
+                    onUpdatePlayerCount = { players -> onUpdatePlayerCount(slot.time, players) },
+                    onRemove = { onRemoveTimeSlot(slot.time) }
+                )
+                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            }
+        }
+
+        // Add Time Button
+        OutlinedButton(
+            onClick = onAddTimeClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(
+                TtcIcons.ADD.painter,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Text(stringResource(TTR.strings.add_time_button.resourceId))
+        }
+    }
+}

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TimeSlotRow.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/common/TimeSlotRow.kt
@@ -1,0 +1,80 @@
+package net.bradball.teetimecaddie.android.feature.teeTimes.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
+import net.bradball.teetimecaddie.core.extensions.formattedTime
+import net.bradball.teetimecaddie.core.models.GR
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.features.teetimes.TTR
+
+/**
+ * A row displaying a single tee time slot with time, player count slider, and remove button.
+ *
+ * This composable is shared between the Add and Edit Tee Time screens.
+ *
+ * @param slot The time slot to display.
+ * @param onUpdatePlayerCount Callback when the player count slider changes.
+ * @param onRemove Callback when the remove button is clicked.
+ */
+@Composable
+fun TimeSlotRow(
+    slot: TeeTimeSlot,
+    onUpdatePlayerCount: (Int) -> Unit,
+    onRemove: () -> Unit
+) {
+    Column {
+        // Time display with trash icon
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = slot.time.formattedTime,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onRemove) {
+                Icon(
+                    TtcIcons.TRASH.painter,
+                    contentDescription = stringResource(GR.strings.delete.resourceId),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        // Player count slider
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(TTR.strings.players_label.resourceId),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Slider(
+                value = slot.numberOfPlayers.toFloat(),
+                onValueChange = { onUpdatePlayerCount(it.toInt()) },
+                valueRange = 1f..4f,
+                steps = 2,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = slot.numberOfPlayers.toString(),
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeScreen.kt
@@ -1,5 +1,6 @@
-package net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime
+package net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -21,71 +23,110 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import net.bradball.teetimecaddie.android.feature.teeTimes.common.TeeTimesSection
 import net.bradball.teetimecaddie.android.theme.MyApplicationTheme
+import net.bradball.teetimecaddie.android.ui.common.Screen
 import net.bradball.teetimecaddie.android.ui.common.TtcDatePicker
 import net.bradball.teetimecaddie.android.ui.common.TtcTimePickerDialog
 import net.bradball.teetimecaddie.android.ui.common.buttons.LoadingButton
 import net.bradball.teetimecaddie.android.ui.common.icons.TtcIcons
 import net.bradball.teetimecaddie.android.ui.common.rememberTtcDatePickerState
 import net.bradball.teetimecaddie.android.ui.common.selectedDate
+import net.bradball.teetimecaddie.android.ui.common.setSelectedDate
+import net.bradball.teetimecaddie.core.analytics.AnalyticsScreen
 import net.bradball.teetimecaddie.core.models.GR
 import net.bradball.teetimecaddie.core.models.TeeTimeSlot
 import net.bradball.teetimecaddie.core.models.previewTeeTimeSlotList
 import net.bradball.teetimecaddie.features.teetimes.TTR
 
 @Composable
-fun AddTeeTimeScreen(
+fun EditTeeTimeScreen(
+    viewModel: EditTeeTimeViewModel,
     onBack: () -> Unit,
-    onTeeTimeCreated: () -> Unit,
-    viewModel: AddTeeTimeViewModel = hiltViewModel()
+    onTeeTimeUpdated: () -> Unit
 ) {
     // Handle save success
     LaunchedEffect(viewModel.saveSuccess) {
         if (viewModel.saveSuccess) {
-            onTeeTimeCreated()
+            onTeeTimeUpdated()
         }
     }
 
-    AddTeeTimeContent(
-        showLoadingProgress = viewModel.showLoadingProgress,
-        timeSlots = viewModel.timeSlots,
-        onAddTimeClick = viewModel::onAddTimeClick,
-        onAddTimeSlot = viewModel::addTimeSlot,
-        onUpdatePlayerCount = viewModel::updatePlayerCount,
-        onRemoveTimeSlot = viewModel::removeTimeSlot,
-        onSaveClick = viewModel::saveTeeTime,
-        onBackClick = onBack
-    )
+    Screen(AnalyticsScreen.EditTeeTime("EditTeeTimeScreen")) {
+        if (viewModel.isLoading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            EditTeeTimeContent(
+                courseName = viewModel.courseName,
+                selectedDate = viewModel.selectedDate,
+                showSaveProgress = viewModel.showSaveProgress,
+                timeSlots = viewModel.timeSlots,
+                hasChanges = viewModel.hasChanges,
+                onCourseNameChange = viewModel::updateCourseName,
+                onDateChange = viewModel::updateDate,
+                onAddTimeClick = viewModel::onAddTimeClick,
+                onAddTimeSlot = viewModel::addTimeSlot,
+                onUpdatePlayerCount = viewModel::updatePlayerCount,
+                onRemoveTimeSlot = viewModel::removeTimeSlot,
+                onSaveClick = viewModel::saveTeeTime,
+                onBackClick = onBack
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AddTeeTimeContent(
-    showLoadingProgress: Boolean,
+private fun EditTeeTimeContent(
+    courseName: String,
+    selectedDate: LocalDate?,
+    showSaveProgress: Boolean,
     timeSlots: List<TeeTimeSlot>,
+    hasChanges: Boolean,
+    onCourseNameChange: (String) -> Unit,
+    onDateChange: (LocalDate?) -> Unit,
     onAddTimeClick: () -> Unit,
     onAddTimeSlot: (LocalTime) -> Boolean,
     onUpdatePlayerCount: (LocalTime, Int) -> Unit,
     onRemoveTimeSlot: (LocalTime) -> Unit,
-    onSaveClick: (String, LocalDate?) -> Unit,
+    onSaveClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
-    var courseName by remember { mutableStateOf("") }
-    val date = rememberTtcDatePickerState()
     var showTimePickerDialog by remember { mutableStateOf(false) }
+    val datePickerState = rememberTtcDatePickerState()
+
+    // Sync the date picker state with the selected date from ViewModel
+    LaunchedEffect(selectedDate) {
+        selectedDate?.let { datePickerState.setSelectedDate(it) }
+    }
+
+    // Notify ViewModel when date changes
+    LaunchedEffect(datePickerState.selectedDate) {
+        onDateChange(datePickerState.selectedDate)
+    }
+
+    // Determine if save should be enabled
+    val canSave = hasChanges &&
+            courseName.isNotBlank() &&
+            datePickerState.selectedDate != null &&
+            timeSlots.isNotEmpty()
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(TTR.strings.add_tee_time.resourceId)) },
+                title = { Text(stringResource(TTR.strings.edit_tee_time.resourceId)) },
                 navigationIcon = {
                     IconButton(onClick = onBackClick) {
                         Icon(TtcIcons.ARROW_BACK.painter, contentDescription = stringResource(GR.strings.back.resourceId))
@@ -104,7 +145,7 @@ private fun AddTeeTimeContent(
             // Course Name TextField
             OutlinedTextField(
                 value = courseName,
-                onValueChange = { courseName = it },
+                onValueChange = onCourseNameChange,
                 label = { Text(stringResource(TTR.strings.field_label_course_name.resourceId)) },
                 modifier = Modifier.fillMaxWidth()
             )
@@ -112,7 +153,7 @@ private fun AddTeeTimeContent(
             Spacer(modifier = Modifier.height(16.dp))
 
             // Date Picker Field
-            TtcDatePicker(pickerState = date)
+            TtcDatePicker(pickerState = datePickerState)
 
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -131,11 +172,11 @@ private fun AddTeeTimeContent(
 
             // Save Button
             LoadingButton(
-                text = stringResource(TTR.strings.button_create.resourceId),
-                onClick = { onSaveClick(courseName, date.selectedDate) },
-                enabled = courseName.isNotBlank() && date.selectedDate != null && timeSlots.isNotEmpty(),
+                text = stringResource(TTR.strings.button_save.resourceId),
+                onClick = onSaveClick,
+                enabled = canSave,
                 modifier = Modifier.fillMaxWidth(),
-                isLoading = showLoadingProgress
+                isLoading = showSaveProgress
             )
         }
     }
@@ -154,16 +195,21 @@ private fun AddTeeTimeContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun AddTeeTimeContentPreview() {
+private fun EditTeeTimeContentPreview() {
     MyApplicationTheme {
-        AddTeeTimeContent(
-            showLoadingProgress = false,
-            timeSlots = emptyList(),
+        EditTeeTimeContent(
+            courseName = "Persimmon Ridge",
+            selectedDate = null,
+            showSaveProgress = false,
+            timeSlots = previewTeeTimeSlotList,
+            hasChanges = false,
+            onCourseNameChange = {},
+            onDateChange = {},
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
             onRemoveTimeSlot = { },
-            onSaveClick = { _, _ -> },
+            onSaveClick = { },
             onBackClick = { }
         )
     }
@@ -171,16 +217,21 @@ private fun AddTeeTimeContentPreview() {
 
 @Preview(showBackground = true)
 @Composable
-private fun AddTeeTimeContentWithTimesPreview() {
+private fun EditTeeTimeContentWithChangesPreview() {
     MyApplicationTheme {
-        AddTeeTimeContent(
-            showLoadingProgress = false,
+        EditTeeTimeContent(
+            courseName = "Persimmon Ridge",
+            selectedDate = null,
+            showSaveProgress = false,
             timeSlots = previewTeeTimeSlotList,
+            hasChanges = true,
+            onCourseNameChange = {},
+            onDateChange = {},
             onAddTimeClick = { },
             onAddTimeSlot = { true },
             onUpdatePlayerCount = { _, _ -> },
             onRemoveTimeSlot = { },
-            onSaveClick = { _, _ -> },
+            onSaveClick = { },
             onBackClick = { }
         )
     }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/editTeeTime/EditTeeTimeViewModel.kt
@@ -1,0 +1,182 @@
+package net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
+import net.bradball.teetimecaddie.core.analytics.EventManager
+import net.bradball.teetimecaddie.core.models.TeeTime
+import net.bradball.teetimecaddie.core.models.TeeTimeSlot
+import net.bradball.teetimecaddie.features.auth.AuthRepository
+import net.bradball.teetimecaddie.features.teetimes.TeeTimesRepository
+
+@AssistedFactory
+interface EditTeeTimeViewModelFactory {
+    fun create(teeTimeId: String): EditTeeTimeViewModel
+}
+
+@HiltViewModel(assistedFactory = EditTeeTimeViewModelFactory::class)
+class EditTeeTimeViewModel @AssistedInject constructor(
+    @Assisted private val teeTimeId: String,
+    private val teeTimesRepo: TeeTimesRepository,
+    private val authRepo: AuthRepository,
+    private val eventManager: EventManager
+): ViewModel() {
+
+    // UI state
+    var isLoading: Boolean by mutableStateOf(true)
+        private set
+
+    var showSaveProgress: Boolean by mutableStateOf(false)
+        private set
+
+    var saveSuccess: Boolean by mutableStateOf(false)
+        private set
+
+    // Original tee time data for change detection
+    private var originalTeeTime: TeeTime? = null
+
+    // Editable fields
+    var courseName: String by mutableStateOf("")
+        private set
+
+    var selectedDate: LocalDate? by mutableStateOf(null)
+        private set
+
+    // List of tee time slots
+    private val _timeSlots = mutableStateListOf<TeeTimeSlot>()
+    val timeSlots: List<TeeTimeSlot> get() = _timeSlots.sortedBy { it.time }
+
+    /**
+     * Whether the form has been modified from its original state.
+     */
+    val hasChanges: Boolean
+        get() {
+            val original = originalTeeTime ?: return false
+            return courseName != original.course ||
+                    selectedDate != original.date ||
+                    _timeSlots.sortedBy { it.time } != original.times.sortedBy { it.time }
+        }
+
+    init {
+        loadTeeTime()
+    }
+
+    private fun loadTeeTime() {
+        viewModelScope.launch {
+            isLoading = true
+            try {
+                // Get the tee time from the repository
+                val teeTimes = teeTimesRepo.getTeeTimes(authRepo.currentUser.id).first()
+                val teeTime = teeTimes.find { it.id == teeTimeId }
+
+                if (teeTime != null) {
+                    originalTeeTime = teeTime
+                    courseName = teeTime.course
+                    selectedDate = teeTime.date
+                    _timeSlots.clear()
+                    _timeSlots.addAll(teeTime.times)
+                }
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    /**
+     * Updates the course name.
+     */
+    fun updateCourseName(name: String) {
+        courseName = name
+    }
+
+    /**
+     * Updates the selected date.
+     */
+    fun updateDate(date: LocalDate?) {
+        selectedDate = date
+    }
+
+    /**
+     * Logs the analytics event when the user clicks the "Add Time" button.
+     */
+    fun onAddTimeClick() {
+        eventManager.logEvent(AnalyticsEvent.AddTimeClick)
+    }
+
+    /**
+     * Adds a new time slot with the default number of players (4).
+     * If the time already exists in the list, it will not be added.
+     *
+     * @param time The time to add.
+     * @return true if the time was added, false if it already existed.
+     */
+    fun addTimeSlot(time: LocalTime): Boolean {
+        if (_timeSlots.any { it.time == time }) {
+            return false
+        }
+        _timeSlots.add(TeeTimeSlot(time = time, numberOfPlayers = 4))
+        eventManager.logEvent(AnalyticsEvent.AddTime)
+        return true
+    }
+
+    /**
+     * Updates the number of players for a specific time slot.
+     *
+     * @param time The time of the slot to update.
+     * @param numberOfPlayers The new number of players (1-4).
+     */
+    fun updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        val index = _timeSlots.indexOfFirst { it.time == time }
+        if (index != -1) {
+            val clampedPlayers = numberOfPlayers.coerceIn(1, 4)
+            _timeSlots[index] = _timeSlots[index].copy(numberOfPlayers = clampedPlayers)
+            eventManager.logEvent(AnalyticsEvent.NumberOfPlayersClick(clampedPlayers))
+        }
+    }
+
+    /**
+     * Removes a time slot from the list and logs the analytics event.
+     *
+     * @param time The time of the slot to remove.
+     */
+    fun removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(AnalyticsEvent.RemoveTimeClick)
+        _timeSlots.removeAll { it.time == time }
+    }
+
+    /**
+     * Saves the updated tee time.
+     */
+    fun saveTeeTime() {
+        val date = selectedDate ?: return
+        val original = originalTeeTime ?: return
+        if (_timeSlots.isEmpty() || courseName.isBlank()) return
+
+        viewModelScope.launch {
+            showSaveProgress = true
+            try {
+                val updatedTeeTime = original.copy(
+                    course = courseName,
+                    date = date,
+                    times = _timeSlots.toList()
+                )
+                teeTimesRepo.updateTeeTime(updatedTeeTime)
+                saveSuccess = true
+            } finally {
+                showSaveProgress = false
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/navigation/TeeTimesNavigation.kt
@@ -1,9 +1,13 @@
 package net.bradball.teetimecaddie.android.feature.teeTimes.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 import net.bradball.teetimecaddie.android.feature.teeTimes.addTeeTime.AddTeeTimeScreen
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeScreen
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeViewModel
+import net.bradball.teetimecaddie.android.feature.teeTimes.editTeeTime.EditTeeTimeViewModelFactory
 import net.bradball.teetimecaddie.android.feature.teeTimes.teeTimeList.TeeTimesListScreen
 import net.bradball.teetimecaddie.android.ui.navigation.Navigator
 import net.bradball.teetimecaddie.android.ui.navigation.TtcNavKey
@@ -25,6 +29,16 @@ data object TeeTimesListDestination: TtcNavKey
 @Serializable
 data object AddTeeTimeDestination: TtcNavKey
 
+/**
+ * Navigation destination for the Edit Tee Time screen.
+ *
+ * Allows users to edit an existing tee time.
+ *
+ * @param teeTimeId The ID of the tee time to edit.
+ */
+@Serializable
+data class EditTeeTimeDestination(val teeTimeId: String): TtcNavKey
+
 
 /**
  * Navigates to the Tee Times list screen.
@@ -45,6 +59,15 @@ fun Navigator.navigateToTeeTimesList(clearBackStack: Boolean = false) {
  */
 fun Navigator.navigateToAddTeeTime() {
     navigate(AddTeeTimeDestination)
+}
+
+/**
+ * Navigates to the Edit Tee Time screen.
+ *
+ * @param teeTimeId The ID of the tee time to edit.
+ */
+fun Navigator.navigateToEditTeeTime(teeTimeId: String) {
+    navigate(EditTeeTimeDestination(teeTimeId))
 }
 
 /**
@@ -94,7 +117,8 @@ fun Navigator.navigateToAddTeeTime() {
 fun EntryProviderScope<NavKey>.teeTimesEntries(navigator: Navigator) {
     entry<TeeTimesListDestination> {
         TeeTimesListScreen(
-            onAddTeeTimeClick = { navigator.navigateToAddTeeTime() }
+            onAddTeeTimeClick = { navigator.navigateToAddTeeTime() },
+            onTeeTimeClick = { teeTimeId -> navigator.navigateToEditTeeTime(teeTimeId) }
         )
     }
 
@@ -102,6 +126,17 @@ fun EntryProviderScope<NavKey>.teeTimesEntries(navigator: Navigator) {
         AddTeeTimeScreen(
             onBack = { navigator.goBack() },
             onTeeTimeCreated = { navigator.goBack() }
+        )
+    }
+
+    entry<EditTeeTimeDestination> { destination ->
+        val viewModel = hiltViewModel<EditTeeTimeViewModel, EditTeeTimeViewModelFactory> { factory ->
+            factory.create(destination.teeTimeId)
+        }
+        EditTeeTimeScreen(
+            viewModel = viewModel,
+            onBack = { navigator.goBack() },
+            onTeeTimeUpdated = { navigator.goBack() }
         )
     }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimeCard.kt
@@ -25,8 +25,13 @@ import net.bradball.teetimecaddie.core.models.previewTeeTime
 import net.bradball.teetimecaddie.core.models.previewTeeTimeList
 
 @Composable
-fun TeeTimeCard(teeTime: TeeTime, modifier: Modifier = Modifier) {
+fun TeeTimeCard(
+    teeTime: TeeTime,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
     Card(
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesScreen.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesScreen.kt
@@ -29,20 +29,26 @@ import net.bradball.teetimecaddie.features.teetimes.TTR
 @Composable
 fun TeeTimesListScreen(
     onAddTeeTimeClick: () -> Unit,
+    onTeeTimeClick: (String) -> Unit,
     viewModel: TeeTimesViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     TeeTimesContent(
         uiState = uiState,
-        onAddTeeTimeClick = onAddTeeTimeClick
+        onAddTeeTimeClick = onAddTeeTimeClick,
+        onTeeTimeClick = { teeTimeId ->
+            viewModel.onTeeTimeClick()
+            onTeeTimeClick(teeTimeId)
+        }
     )
 }
 
 @Composable
 fun TeeTimesContent(
     uiState: TeeTimesUiState,
-    onAddTeeTimeClick: () -> Unit = {}
+    onAddTeeTimeClick: () -> Unit = {},
+    onTeeTimeClick: (String) -> Unit = {}
 ) {
 
     Scaffold(
@@ -66,7 +72,10 @@ fun TeeTimesContent(
                             .fillMaxWidth()
                     )
 
-                    is TeeTimesUiState.Content -> TeeTimesList(uiState.teeTimes)
+                    is TeeTimesUiState.Content -> TeeTimesList(
+                        teeTimes = uiState.teeTimes,
+                        onTeeTimeClick = onTeeTimeClick
+                    )
                 }
             }
         }
@@ -74,11 +83,16 @@ fun TeeTimesContent(
 }
 
 @Composable
-private fun TeeTimesList(teeTimes: List<TeeTime>) {
+private fun TeeTimesList(
+    teeTimes: List<TeeTime>,
+    onTeeTimeClick: (String) -> Unit
+) {
     LazyColumn(modifier = Modifier.padding(16.dp)) {
         items(teeTimes.size) { index ->
+            val teeTime = teeTimes[index]
             TeeTimeCard(
-                teeTime = teeTimes[index],
+                teeTime = teeTime,
+                onClick = { teeTime.id?.let { onTeeTimeClick(it) } },
                 modifier = Modifier.padding(bottom = 8.dp)
             )
         }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesViewModel.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/feature/teeTimes/teeTimeList/TeeTimesViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import net.bradball.teetimecaddie.core.analytics.AnalyticsEvent
+import net.bradball.teetimecaddie.core.analytics.EventManager
 import net.bradball.teetimecaddie.core.models.TeeTime
 import net.bradball.teetimecaddie.features.auth.AuthRepository
 import net.bradball.teetimecaddie.features.teetimes.TeeTimesRepository
@@ -28,7 +30,8 @@ sealed interface TeeTimesUiState {
 @HiltViewModel
 class TeeTimesViewModel @Inject constructor(
     private val teeTimesRepo: TeeTimesRepository,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val eventManager: EventManager
 ): ViewModel() {
 
     val uiState: StateFlow<TeeTimesUiState> = teeTimesRepo.getTeeTimes(authRepository.currentUser.id)
@@ -44,4 +47,11 @@ class TeeTimesViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(1_000),
             initialValue = TeeTimesUiState.Loading
         )
+
+    /**
+     * Logs the analytics event when a tee time is clicked.
+     */
+    fun onTeeTimeClick() {
+        eventManager.logEvent(AnalyticsEvent.TeeTimeListItemClick)
+    }
 }

--- a/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/DatePicker.kt
+++ b/android/app/src/main/java/net/bradball/teetimecaddie/android/ui/common/DatePicker.kt
@@ -151,9 +151,9 @@ val DatePickerState.selectedDate: LocalDate?
  *
  * @param date A LocalDate to use to set the selected date.
  */
-//fun DatePickerState.setSelection(date: LocalDate?) {
-//    this.selectedDateMillis = date?.toEpochMilliseconds(TimeZone.UTC)
-//}
+fun DatePickerState.setSelectedDate(date: LocalDate?) {
+    this.selectedDateMillis = date?.toEpochMilliseconds(TimeZone.UTC)
+}
 
 @Preview(showBackground = true, showSystemUi = true, backgroundColor = 0xFFFFFFFF,)
 @Composable

--- a/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsEvent.kt
@@ -81,6 +81,10 @@ sealed class AnalyticsEvent(val name: String, internal val type: EventType) {
     data class NumberOfPlayersClick(val numberOfPlayers: Int): AnalyticsEvent("number_of_players_click", EventType.CLICK)
     @Serializable
     object RemoveTimeClick: AnalyticsEvent("remove_time_click", EventType.CLICK)
+    @Serializable
+    object TeeTimeListItemClick: AnalyticsEvent("tee_time_list_item_click", EventType.CLICK)
+    @Serializable
+    data class TeeTimeEdit(val times: Int, val players: Int): AnalyticsEvent("tee_time_edit", EventType.OPERATION)
 
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/net/bradball/teetimecaddie/core/analytics/AnalyticsScreen.kt
@@ -68,4 +68,7 @@ sealed class AnalyticsScreen(val name: String, val viewName: String, val paramet
 
     /** The screen for adding a new tee time */
     class AddTeeTime(viewName: String): AnalyticsScreen(name = "AddTeeTime", viewName)
+
+    /** The screen for editing an existing tee time */
+    class EditTeeTime(viewName: String): AnalyticsScreen(name = "EditTeeTime", viewName)
 }

--- a/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
+++ b/core/storage/src/commonMain/kotlin/net/bradbal/teetimecaddie/core/storage/TeeTimeStorage.kt
@@ -37,6 +37,17 @@ class TeeTimeStorage {
      */
     suspend fun addTeeTime(document: TeeTimeDocument): String = teeTimesCollection.add(document).id
 
+    /**
+     * Update an existing Tee Time in the database.
+     *
+     * @param document A [TeeTimeDocument] with updated information. The document's id must be set.
+     * @throws IllegalArgumentException if the document id is null.
+     */
+    suspend fun updateTeeTime(document: TeeTimeDocument) {
+        val docId = document.id ?: throw IllegalArgumentException("Document id must be set for update")
+        teeTimesCollection.document(docId).set(document)
+    }
+
     @OptIn(ExperimentalTime::class)
     suspend fun getTeeTimes(playerId: String): List<TeeTimeDocument> {
         val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date

--- a/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
+++ b/features/teetimes/src/commonMain/kotlin/net/bradball/teetimecaddie/features/teetimes/TeeTimesRepository.kt
@@ -62,4 +62,31 @@ class TeeTimesRepository(
         .mapLatest { list ->
             list.map { it.toModel() }
         }
+
+    /**
+     * Updates an existing tee time.
+     *
+     * @param teeTime The tee time to update. Must have a non-null id.
+     * @return The updated TeeTime.
+     * @throws IllegalArgumentException if the tee time id is null.
+     */
+    @Throws(CancellationException::class, IllegalArgumentException::class)
+    suspend fun updateTeeTime(teeTime: TeeTime): TeeTime {
+        requireNotNull(teeTime.id) { "TeeTime id must not be null for update" }
+
+        val sortedTimes = teeTime.times.sortedBy { it.time }
+        val doc = teeTime.copy(times = sortedTimes).toDocument().apply {
+            id = teeTime.id
+        }
+
+        teeTimeStorage.updateTeeTime(doc)
+
+        val totalPlayers = sortedTimes.fold(0) { total, slot ->
+            total + slot.numberOfPlayers
+        }
+
+        eventManager.logEvent(AnalyticsEvent.TeeTimeEdit(sortedTimes.count(), totalPlayers))
+
+        return doc.toModel()
+    }
 }

--- a/features/teetimes/src/commonMain/moko-resources/base/strings.xml
+++ b/features/teetimes/src/commonMain/moko-resources/base/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="tee_times_title">Tee Times</string>
     <string name="add_tee_time">Add Tee Time</string>
+    <string name="edit_tee_time">Edit Tee Time</string>
     <string name="empty_tee_times_title">Tee Sheet is Wide Open</string>
     <string name="empty_tee_times_message">You don\'t have an scheduled tee times.</string>
 
@@ -10,6 +11,7 @@
     <string name="field_Label_Time">Time</string>
     <string name="field_Label_Players">Number of Players</string>
     <string name="button_create">Create</string>
+    <string name="button_save">Save</string>
 
     <!-- Multiple tee times -->
     <string name="tee_times_section_header">Tee Times</string>

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeeTimesNavStack.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeeTimesNavStack.swift
@@ -2,16 +2,18 @@ import SwiftUI
 
 struct TeeTimesNavStack: View {
     private let navigator: Navigator
-    
+
     init(navigator: Navigator) {
         self.navigator = navigator
     }
-    
+
     var body: some View {
         NavigationStack(path: navigator.backstack(for: .teeTimes)) {
             AppTabs.teeTimes.destinationView(navigator)
                 .navigationDestination(for: AnyTtcNavKey.self) { key in
                     switch key.wrapped {
+                    case let destination as TeeTimesDestinations:
+                        destination.destinationView(navigator)
                     default: fatalError("Unhandled navigation key: \(key)")
                     }
                 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/TeetimesNavigation.swift
@@ -10,14 +10,16 @@ import TeeTimeCaddieKit
 enum TeeTimesDestinations: @MainActor TtcNavKey {
     case teeTimesList
     case addTeeTime
+    case editTeeTime(teeTimeId: String)
 
     @ViewBuilder
     func destinationView(_ navigator: Navigator) -> some View {
-       
+
         switch self {
         case .teeTimesList:
             TeeTimesListScreen(
-                onAddTeeTimeClick: { navigator.navigateToAddTeeTime() }
+                onAddTeeTimeClick: { navigator.navigateToAddTeeTime() },
+                onTeeTimeClick: { teeTimeId in navigator.navigateToEditTeeTime(teeTimeId: teeTimeId) }
             )
             .navigationTitle(TTR.strings().tee_times_title.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
@@ -28,6 +30,15 @@ enum TeeTimesDestinations: @MainActor TtcNavKey {
                 onTeeTimeCreated: { navigator.pop() }
             )
             .navigationTitle(TTR.strings().add_tee_time.desc().localized())
+            .navigationBarTitleDisplayMode(.inline)
+
+        case .editTeeTime(let teeTimeId):
+            EditTeeTimeScreen(
+                teeTimeId: teeTimeId,
+                onBack: { navigator.pop() },
+                onTeeTimeUpdated: { navigator.pop() }
+            )
+            .navigationTitle(TTR.strings().edit_tee_time.desc().localized())
             .navigationBarTitleDisplayMode(.inline)
         }
     }
@@ -45,5 +56,9 @@ extension Navigator {
 
     func navigateToAddTeeTime() {
         self.navigate(to: TeeTimesDestinations.addTeeTime)
+    }
+
+    func navigateToEditTeeTime(teeTimeId: String) {
+        self.navigate(to: TeeTimesDestinations.editTeeTime(teeTimeId: teeTimeId))
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/addTeeTime/AddTeeTimeViewModel.swift
@@ -106,27 +106,3 @@ class AddTeeTimeViewModel {
     }
 }
 
-// MARK: - Date Conversion Extensions
-extension Date {
-    func toLocalDate() -> LocalDate {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: self)
-        return LocalDate(
-            year: Int32(components.year ?? 2024),
-            month: Int32(components.month ?? 1),
-            day: Int32(components.day ?? 1)
-        )
-    }
-
-    func toLocalTime() -> LocalTime {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.hour, .minute], from: self)
-        return LocalTime(
-            hour: Int32(components.hour ?? 0),
-            minute: Int32(components.minute ?? 0),
-            second: 0,
-            nanosecond: 0
-        )
-    }
-}
-

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TeeTimesSection.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TeeTimesSection.swift
@@ -1,0 +1,49 @@
+//
+//  TeeTimesSection.swift
+//  TeeTimeCaddie
+//
+
+import SwiftUI
+import TeeTimeCaddieKit
+
+/// A section displaying a list of tee time slots with an "Add Time" button.
+///
+/// This view is shared between the Add and Edit Tee Time screens.
+struct TeeTimesSection: View {
+    let timeSlots: [TeeTimeSlot]
+    let onAddTimeClick: () -> Void
+    let onUpdatePlayerCount: (LocalTime, Int) -> Void
+    let onRemoveTimeSlot: (LocalTime) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Section Header
+            Text(TTR.strings().tee_times_section_header.desc().localized())
+                .font(.headline)
+
+            // List of time slots
+            ForEach(timeSlots, id: \.time) { slot in
+                TimeSlotRow(
+                    slot: slot,
+                    onUpdatePlayerCount: { players in
+                        onUpdatePlayerCount(slot.time, players)
+                    },
+                    onRemove: {
+                        onRemoveTimeSlot(slot.time)
+                    }
+                )
+                Divider()
+            }
+
+            // Add Time Button
+            Button(action: onAddTimeClick) {
+                HStack {
+                    Image(systemName: "plus")
+                    Text(TTR.strings().add_time_button.desc().localized())
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TimePickerSheet.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TimePickerSheet.swift
@@ -1,0 +1,43 @@
+//
+//  TimePickerSheet.swift
+//  TeeTimeCaddie
+//
+
+import SwiftUI
+import TeeTimeCaddieKit
+
+/// A sheet for selecting a time using a wheel picker.
+///
+/// This view is shared between the Add and Edit Tee Time screens.
+struct TimePickerSheet: View {
+    @Binding var selectedTime: Date
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            DatePicker(
+                "",
+                selection: $selectedTime,
+                displayedComponents: .hourAndMinute
+            )
+            .datePickerStyle(.wheel)
+            .labelsHidden()
+            .navigationTitle(TTR.strings().field_Label_Time.desc().localized())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(GR.strings().cancel.desc().localized()) {
+                        onCancel()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(GR.strings().ok.desc().localized()) {
+                        onConfirm()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TimeSlotRow.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/common/TimeSlotRow.swift
@@ -1,0 +1,55 @@
+//
+//  TimeSlotRow.swift
+//  TeeTimeCaddie
+//
+
+import SwiftUI
+import TeeTimeCaddieKit
+
+/// A row displaying a single tee time slot with time, player count slider, and remove button.
+///
+/// This view is shared between the Add and Edit Tee Time screens.
+struct TimeSlotRow: View {
+    let slot: TeeTimeSlot
+    let onUpdatePlayerCount: (Int) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Time display with trash icon
+            HStack {
+                Text(slot.time.formattedTime)
+                    .font(.headline)
+
+                Spacer()
+
+                Button(action: onRemove) {
+                    Image("icons/trash")
+                        .foregroundColor(.red)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(GR.strings().delete.desc().localized())
+            }
+
+            // Player count slider
+            HStack {
+                Text(TTR.strings().players_label.desc().localized())
+                    .font(.body)
+
+                Slider(
+                    value: Binding(
+                        get: { Double(slot.numberOfPlayers) },
+                        set: { onUpdatePlayerCount(Int($0)) }
+                    ),
+                    in: 1...4,
+                    step: 1
+                )
+
+                Text("\(slot.numberOfPlayers)")
+                    .font(.headline)
+                    .frame(width: 30)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeScreen.swift
@@ -1,25 +1,18 @@
 //
-//  AddTeeTimeScreen.swift
+//  EditTeeTimeScreen.swift
 //  TeeTimeCaddie
-//
-//  Created by Bradley Ball on 1/10/26.
 //
 
 import SwiftUI
 import TeeTimeCaddieKit
 
-struct AddTeeTimeScreen: View {
+struct EditTeeTimeScreen: View {
+    let teeTimeId: String
     let onBack: () -> Void
-    let onTeeTimeCreated: () -> Void
+    let onTeeTimeUpdated: () -> Void
 
     @State
-    private var viewModel = AddTeeTimeViewModel()
-
-    @State
-    var courseName: String = ""
-
-    @State
-    var selectedDate: Date = Date()
+    private var viewModel: EditTeeTimeViewModel?
 
     @State
     private var showTimePicker: Bool = false
@@ -33,39 +26,56 @@ struct AddTeeTimeScreen: View {
     ) ?? Date()
 
     var body: some View {
-        Screen(AnalyticsScreen.AddTeeTime(viewName: self.viewName)) {
-            AddTeeTimeContent(
-                courseName: $courseName,
-                selectedDate: $selectedDate,
-                timeSlots: viewModel.timeSlots,
-                isLoading: viewModel.showLoadingProgress,
-                onAddTimeClick: {
-                    viewModel.onAddTimeClick()
-                    showTimePicker = true
-                },
-                onUpdatePlayerCount: viewModel.updatePlayerCount,
-                onRemoveTimeSlot: viewModel.removeTimeSlot,
-                onSave: {
-                    viewModel.saveTeeTime(
-                        courseName: courseName,
-                        selectedDate: selectedDate
+        Screen(AnalyticsScreen.EditTeeTime(viewName: self.viewName)) {
+            if let vm = viewModel {
+                if vm.isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    EditTeeTimeContent(
+                        courseName: Binding(
+                            get: { vm.courseName },
+                            set: { vm.updateCourseName($0) }
+                        ),
+                        selectedDate: Binding(
+                            get: { vm.selectedDate },
+                            set: { vm.updateDate($0) }
+                        ),
+                        timeSlots: vm.timeSlots,
+                        isLoading: vm.showSaveProgress,
+                        hasChanges: vm.hasChanges,
+                        onAddTimeClick: {
+                            vm.onAddTimeClick()
+                            showTimePicker = true
+                        },
+                        onUpdatePlayerCount: vm.updatePlayerCount,
+                        onRemoveTimeSlot: vm.removeTimeSlot,
+                        onSave: vm.saveTeeTime
                     )
                 }
-            )
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = EditTeeTimeViewModel(teeTimeId: teeTimeId)
+            }
         }
         .sheet(isPresented: $showTimePicker) {
             TimePickerSheet(
                 selectedTime: $selectedTimeForPicker,
                 onCancel: { showTimePicker = false },
                 onConfirm: {
-                    viewModel.addTimeSlot(time: selectedTimeForPicker)
+                    viewModel?.addTimeSlot(time: selectedTimeForPicker)
                     showTimePicker = false
                 }
             )
         }
-        .onChange(of: viewModel.saveSuccess) { _, newValue in
+        .onChange(of: viewModel?.saveSuccess ?? false) { _, newValue in
             if newValue {
-                onTeeTimeCreated()
+                onTeeTimeUpdated()
             }
         }
     }
@@ -73,18 +83,19 @@ struct AddTeeTimeScreen: View {
 
 // MARK: - Content View
 
-fileprivate struct AddTeeTimeContent: View {
+fileprivate struct EditTeeTimeContent: View {
     @Binding var courseName: String
     @Binding var selectedDate: Date
     let timeSlots: [TeeTimeSlot]
     let isLoading: Bool
+    let hasChanges: Bool
     let onAddTimeClick: () -> Void
     let onUpdatePlayerCount: (LocalTime, Int) -> Void
     let onRemoveTimeSlot: (LocalTime) -> Void
     let onSave: () -> Void
 
     private var canSave: Bool {
-        !courseName.isEmpty && !timeSlots.isEmpty
+        hasChanges && !courseName.isEmpty && !timeSlots.isEmpty
     }
 
     var body: some View {
@@ -116,7 +127,7 @@ fileprivate struct AddTeeTimeContent: View {
                     .frame(height: 32)
 
                 // Save Button
-                LoadingButton(TTR.strings().button_create.desc().localized(), isLoading: isLoading, action: onSave)
+                LoadingButton(TTR.strings().button_save.desc().localized(), isLoading: isLoading, action: onSave)
                     .buttonStyle(.Filled)
                     .disabled(!canSave)
             }
@@ -127,39 +138,27 @@ fileprivate struct AddTeeTimeContent: View {
 
 // MARK: - Previews
 
-#Preview("Empty") {
+#Preview("Edit Screen") {
     TeeTimeCaddieTheme {
         NavigationStack {
-            AddTeeTimeScreen(
-                onBack: {},
-                onTeeTimeCreated: {}
-            )
-            .navigationTitle(TTR.strings().add_tee_time.desc().localized())
-            .navigationBarTitleDisplayMode(.inline)
-        }
-    }
-}
-
-#Preview("With Times") {
-    TeeTimeCaddieTheme {
-        NavigationStack {
-            AddTeeTimeContentPreviewWrapper()
-                .navigationTitle(TTR.strings().add_tee_time.desc().localized())
+            EditTeeTimeContentPreviewWrapper()
+                .navigationTitle(TTR.strings().edit_tee_time.desc().localized())
                 .navigationBarTitleDisplayMode(.inline)
         }
     }
 }
 
-fileprivate struct AddTeeTimeContentPreviewWrapper: View {
+fileprivate struct EditTeeTimeContentPreviewWrapper: View {
     @State var courseName: String = "Persimmon Ridge"
     @State var selectedDate: Date = Date()
 
     var body: some View {
-        AddTeeTimeContent(
+        EditTeeTimeContent(
             courseName: $courseName,
             selectedDate: $selectedDate,
             timeSlots: TeeTimeKt.previewTeeTimeSlotList,
             isLoading: false,
+            hasChanges: true,
             onAddTimeClick: {},
             onUpdatePlayerCount: { _, _ in },
             onRemoveTimeSlot: { _ in },

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/editTeeTime/EditTeeTimeViewModel.swift
@@ -1,0 +1,167 @@
+//
+//  EditTeeTimeViewModel.swift
+//  TeeTimeCaddie
+//
+
+import Foundation
+import TeeTimeCaddieKit
+
+@Observable
+class EditTeeTimeViewModel {
+    private let teeTimesRepo: TeeTimesRepository
+    private let authRepo: AuthRepository
+    private let eventManager: EventManager
+    private let teeTimeId: String
+
+    private(set) var isLoading: Bool = true
+    private(set) var showSaveProgress: Bool = false
+    private(set) var saveSuccess: Bool = false
+
+    /// Original tee time data for change detection
+    private var originalTeeTime: TeeTime?
+
+    /// Editable fields
+    private(set) var courseName: String = ""
+    private(set) var selectedDate: Date = Date()
+
+    /// List of tee time slots, sorted by time
+    private(set) var timeSlots: [TeeTimeSlot] = []
+
+    /// Whether the form has been modified from its original state.
+    var hasChanges: Bool {
+        guard let original = originalTeeTime else { return false }
+
+        let originalDate = original.date.toDate()
+        let currentSlotsSorted = timeSlots.sorted { $0.time.compareTo(other: $1.time) < 0 }
+        let originalSlotsSorted = original.times.sorted { $0.time.compareTo(other: $1.time) < 0 }
+
+        return courseName != original.course ||
+            !Calendar.current.isDate(selectedDate, inSameDayAs: originalDate) ||
+            currentSlotsSorted != originalSlotsSorted
+    }
+
+    init(
+        teeTimeId: String,
+        teeTimesRepo: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
+        authRepo: AuthRepository = AuthModule.shared.authRepository(),
+        eventManager: EventManager = AppModule.shared.eventManager()
+    ) {
+        self.teeTimeId = teeTimeId
+        self.teeTimesRepo = teeTimesRepo
+        self.authRepo = authRepo
+        self.eventManager = eventManager
+
+        Task {
+            await loadTeeTime()
+        }
+    }
+
+    @MainActor
+    private func loadTeeTime() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            // Get the first emission from the flow
+            for try await teeTimes in teeTimesRepo.getTeeTimes(player: authRepo.currentUser.id) {
+                if let teeTime = teeTimes.first(where: { $0.id == teeTimeId }) {
+                    originalTeeTime = teeTime
+                    courseName = teeTime.course
+                    selectedDate = teeTime.date.toDate()
+                    timeSlots = Array(teeTime.times)
+                }
+                break // Only need the first emission
+            }
+        } catch {
+            print("Error loading tee time: \(error)")
+        }
+    }
+
+    /// Updates the course name.
+    func updateCourseName(_ name: String) {
+        courseName = name
+    }
+
+    /// Updates the selected date.
+    func updateDate(_ date: Date) {
+        selectedDate = date
+    }
+
+    /// Logs the analytics event when the user clicks the "Add Time" button.
+    func onAddTimeClick() {
+        eventManager.logEvent(event: AnalyticsEvent.AddTimeClick())
+    }
+
+    /// Adds a new time slot with the default number of players (4).
+    /// If the time already exists in the list, it will not be added.
+    /// - Parameter time: The time to add (as a Date).
+    /// - Returns: true if the time was added, false if it already existed.
+    @discardableResult
+    func addTimeSlot(time: Date) -> Bool {
+        let localTime = time.toLocalTime()
+
+        // Check if time already exists
+        if timeSlots.contains(where: { $0.time == localTime }) {
+            return false
+        }
+
+        let newSlot = TeeTimeSlot(time: localTime, numberOfPlayers: 4)
+        timeSlots.append(newSlot)
+        timeSlots.sort { $0.time.compareTo(other: $1.time) < 0 }
+        eventManager.logEvent(event: AnalyticsEvent.AddTime())
+        return true
+    }
+
+    /// Updates the number of players for a specific time slot.
+    /// - Parameters:
+    ///   - time: The LocalTime of the slot to update.
+    ///   - numberOfPlayers: The new number of players (1-4).
+    func updatePlayerCount(time: LocalTime, numberOfPlayers: Int) {
+        guard let index = timeSlots.firstIndex(where: { $0.time == time }) else { return }
+        let clampedPlayers = min(max(numberOfPlayers, 1), 4)
+        timeSlots[index] = TeeTimeSlot(time: time, numberOfPlayers: Int32(clampedPlayers))
+        eventManager.logEvent(event: AnalyticsEvent.NumberOfPlayersClick(numberOfPlayers: Int32(clampedPlayers)))
+    }
+
+    /// Removes a time slot from the list and logs the analytics event.
+    /// - Parameter time: The LocalTime of the slot to remove.
+    func removeTimeSlot(time: LocalTime) {
+        eventManager.logEvent(event: AnalyticsEvent.RemoveTimeClick())
+        timeSlots.removeAll { $0.time == time }
+    }
+
+    /// Saves the updated tee time.
+    func saveTeeTime() {
+        guard !courseName.isEmpty, !timeSlots.isEmpty, let original = originalTeeTime else {
+            return
+        }
+
+        Task {
+            await performSave(original: original)
+        }
+    }
+
+    @MainActor
+    private func performSave(original: TeeTime) async {
+        showSaveProgress = true
+        defer { showSaveProgress = false }
+
+        do {
+            let localDate = selectedDate.toLocalDate()
+
+            let updatedTeeTime = TeeTime(
+                id: original.id,
+                createdBy: original.createdBy,
+                course: courseName,
+                date: localDate,
+                times: timeSlots
+            )
+
+            _ = try await teeTimesRepo.updateTeeTime(teeTime: updatedTeeTime)
+
+            saveSuccess = true
+        } catch {
+            print("Error saving tee time: \(error)")
+        }
+    }
+}

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimeRow.swift
@@ -77,19 +77,6 @@ struct TeeTimeRow: View {
 
 }
 
-// Extension to convert Kotlin LocalDate to Swift Date
-private extension LocalDate {
-    func toDate() -> Date {
-        let calendar = Calendar.current
-        let components = DateComponents(
-            year: Int(self.year),
-            month: Int(self.month.number),
-            day: Int(self.day)
-        )
-        return calendar.date(from: components) ?? Date()
-    }
-}
-
 #Preview {
     TeeTimeRow(teeTime: TeeTimeKt.previewTeeTime)
         .padding()

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreen.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreen.swift
@@ -11,13 +11,20 @@ import TeeTimeCaddieKit
 
 struct TeeTimesListScreen: View {
     let onAddTeeTimeClick: () -> Void
+    let onTeeTimeClick: (String) -> Void
 
     @State
     private var viewModel = TeeTimesListScreenViewModel()
 
     var body: some View {
         Screen(AnalyticsScreen.TeeTimeList(viewName: self.viewName)) {
-            TeeTimesListContent(uiState: viewModel.uiState)
+            TeeTimesListContent(
+                uiState: viewModel.uiState,
+                onTeeTimeClick: { teeTimeId in
+                    viewModel.onTeeTimeClick()
+                    onTeeTimeClick(teeTimeId)
+                }
+            )
         }
         .task { await viewModel.loadTeetimes() }
         .toolbar {
@@ -31,11 +38,13 @@ struct TeeTimesListScreen: View {
 
 fileprivate struct TeeTimesListContent: View {
     private var uiState: UiState<[TeeTime]>
-    
-    init(uiState: UiState<[TeeTime]>) {
+    private var onTeeTimeClick: (String) -> Void
+
+    init(uiState: UiState<[TeeTime]>, onTeeTimeClick: @escaping (String) -> Void) {
         self.uiState = uiState
+        self.onTeeTimeClick = onTeeTimeClick
     }
-        
+
     var body: some View {
         switch uiState {
             case .Loading:
@@ -48,25 +57,29 @@ fileprivate struct TeeTimesListContent: View {
                     icon: .teeEmpty)
 
             case .Content(let list):
-                TeeTimesList(list, onItemTapped: {teeTime in })
+                TeeTimesList(list, onItemTapped: { teeTime in
+                    if let teeTimeId = teeTime.id {
+                        onTeeTimeClick(teeTimeId)
+                    }
+                })
         }
     }
 }
 
 #Preview("Content") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Content(TeeTimeKt.previewTeeTimeList))
+        TeeTimesListContent(uiState: .Content(TeeTimeKt.previewTeeTimeList), onTeeTimeClick: { _ in })
     }
 }
 
 #Preview("Loading") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Loading)
+        TeeTimesListContent(uiState: .Loading, onTeeTimeClick: { _ in })
     }
 }
 
 #Preview("Empty") {
     TeeTimeCaddieTheme {
-        TeeTimesListContent(uiState: .Empty)
+        TeeTimesListContent(uiState: .Empty, onTeeTimeClick: { _ in })
     }
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreenViewModel.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/features/teetimes/teeTimesListScreen/TeeTimesListScreenViewModel.swift
@@ -6,29 +6,37 @@ class TeeTimesListScreenViewModel {
 
     private let teeTimesRepo: TeeTimesRepository
     private let authRepo: AuthRepository
+    private let eventManager: EventManager
 
     init(teeTimesRepository: TeeTimesRepository = TeeTimesModule.shared.teeTimesRepository(),
-         authRepository: AuthRepository = AuthModule.shared.authRepository()) {
+         authRepository: AuthRepository = AuthModule.shared.authRepository(),
+         eventManager: EventManager = AppModule.shared.eventManager()) {
         self.teeTimesRepo = teeTimesRepository
         self.authRepo = authRepository
+        self.eventManager = eventManager
     }
 
     private(set) var uiState: UiState<[TeeTime]> = .Loading
-    
+
     var addButtonEnabled: Bool {
         uiState != .Loading
     }
-    
+
     func loadTeetimes() async {
-        
+
         if !uiState.hasContent {
             uiState = .Loading
         }
-        
+
         for await teeTimesList in teeTimesRepo.getTeeTimes(player: authRepo.currentUser.id) {
             print("Got TeeTimes \(teeTimesList.count)")
             uiState = (teeTimesList.isEmpty) ? .Empty : .Content(teeTimesList)
         }
     }
-    
+
+    /// Logs the analytics event when a tee time is clicked.
+    func onTeeTimeClick() {
+        eventManager.logEvent(event: AnalyticsEvent.TeeTimeListItemClick())
+    }
+
 }

--- a/ios/TeeTimeCaddie/TeeTimeCaddie/Source/util/DateExtensions.swift
+++ b/ios/TeeTimeCaddie/TeeTimeCaddie/Source/util/DateExtensions.swift
@@ -6,14 +6,51 @@
 //
 
 import Foundation
+import TeeTimeCaddieKit
 
 extension Date {
-    
+
     static var today: Date {
         return Calendar.current.startOfDay(for: Date())
     }
-    
+
     func add(_ value: Int, interval: Calendar.Component) -> Date {
         return Calendar.current.date(byAdding: interval, value: value, to: self) ?? self.advanced(by: .zero)
+    }
+
+    /// Converts a Swift Date to a Kotlin LocalDate.
+    func toLocalDate() -> LocalDate {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: self)
+        return LocalDate(
+            year: Int32(components.year ?? 2024),
+            month: Int32(components.month ?? 1),
+            day: Int32(components.day ?? 1)
+        )
+    }
+
+    /// Converts a Swift Date to a Kotlin LocalTime.
+    func toLocalTime() -> LocalTime {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute], from: self)
+        return LocalTime(
+            hour: Int32(components.hour ?? 0),
+            minute: Int32(components.minute ?? 0),
+            second: 0,
+            nanosecond: 0
+        )
+    }
+}
+
+extension LocalDate {
+    /// Converts a Kotlin LocalDate to a Swift Date.
+    func toDate() -> Date {
+        let calendar = Calendar.current
+        let components = DateComponents(
+            year: Int(self.year),
+            month: Int(self.monthNumber),
+            day: Int(self.dayOfMonth)
+        )
+        return calendar.date(from: components) ?? Date()
     }
 }


### PR DESCRIPTION
## Summary
- Add ability to edit existing tee times on both Android and iOS
- Clicking a tee time in the list navigates to the Edit screen
- Edit screen pre-populates with existing data
- Save button enabled only when valid changes are made
- Analytics events logged for list item clicks and tee time edits

## Changes
- **KMP**: Add `updateTeeTime()` to TeeTimeStorage and TeeTimesRepository
- **KMP**: Add `TeeTimeListItemClick` (CLICK) and `TeeTimeEdit` (OPERATION) analytics events
- **KMP**: Add `EditTeeTime` analytics screen and string resources
- **Android/iOS**: Extract shared form components (`TeeTimesSection`, `TimeSlotRow`) to `common/` folders
- **Android**: Create `EditTeeTimeScreen` and `EditTeeTimeViewModel` with Assisted Injection
- **iOS**: Create `EditTeeTimeScreen` and `EditTeeTimeViewModel`
- **iOS**: Consolidate date conversion extensions in `DateExtensions.swift`

## Test Plan
- [ ] Tap a tee time in the list and verify navigation to Edit screen
- [ ] Verify form is pre-populated with existing tee time data
- [ ] Verify Save button is disabled when no changes are made
- [ ] Make changes and verify Save button becomes enabled
- [ ] Save changes and verify navigation back to list
- [ ] Verify analytics events are logged correctly
- [ ] Test on both Android and iOS


🤖 Generated with [Claude Code](https://claude.com/claude-code)